### PR TITLE
Binary sensors should be really binary sensor entities

### DIFF
--- a/custom_components/cz_energy_spot_prices/__init__.py
+++ b/custom_components/cz_energy_spot_prices/__init__.py
@@ -4,8 +4,7 @@ import logging
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_CURRENCY, CONF_UNIT_OF_MEASUREMENT, STATE_ON, STATE_OFF
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.const import CONF_CURRENCY, CONF_UNIT_OF_MEASUREMENT
 
 from .const import DOMAIN, PLATFORMS
 from .coordinator import SpotRateCoordinator
@@ -14,11 +13,7 @@ from .spot_rate import SpotRate
 
 logger = logging.getLogger(__name__)
 
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Setup our skeleton component."""
-    hass.data[DOMAIN] = {}
-    return True
+type SpotRateConfigEntry = ConfigEntry[SpotRateCoordinator]
 
 
 async def options_update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
@@ -27,7 +22,7 @@ async def options_update_listener(hass: HomeAssistant, config_entry: ConfigEntry
     await hass.config_entries.async_reload(config_entry.entry_id)
 
 
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEntry):
     logger.debug('async_setup_entry %s data: [%s]; options: [%s]', config_entry.unique_id, config_entry.data, config_entry.options)
 
     spot_rate = SpotRate()
@@ -38,18 +33,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         unit=config_entry.data[CONF_UNIT_OF_MEASUREMENT],
     )
 
-    hass.data[DOMAIN][config_entry.entry_id] = coordinator
+    config_entry.runtime_data = coordinator
+    config_entry.async_on_unload(config_entry.add_update_listener(options_update_listener))
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-
-    hass_data = dict(config_entry.data)
-    # Registers update listener to update config entry when options are updated.
-    unsub_options_update_listener = config_entry.add_update_listener(options_update_listener)
-    # Store a reference to the unsubscribe function to cleanup if an entry is unloaded.
-    hass_data["unsub_options_update_listener"] = unsub_options_update_listener
-    hass.data[DOMAIN][config_entry.entry_id] = hass_data
-
-    config_entry.async_on_unload(config_entry.add_update_listener(async_reload_entry))
 
     return True
 
@@ -57,10 +44,3 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Unload config entry."""
     return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
-
-
-async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    logger.debug('async_reload_entry %s data: %s; options: %s', config_entry.unique_id, config_entry.data, config_entry.options)
-
-    await hass.config_entries.async_reload(config_entry.entry_id)

--- a/custom_components/cz_energy_spot_prices/binary_sensor.py
+++ b/custom_components/cz_energy_spot_prices/binary_sensor.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from homeassistant.const import CONF_CURRENCY, CONF_UNIT_OF_MEASUREMENT
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.core import HomeAssistant
+
+from . import SpotRateConfigEntry
+from .coordinator import SpotRateCoordinator, SpotRateData, CONSECUTIVE_HOURS
+from .spot_rate_mixin import SpotRateSensorMixin
+from .spot_rate_settings import SpotRateSettings
+
+logger = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: SpotRateConfigEntry, async_add_entities):
+    logger.info('async_setup_entry %s, data: [%s] options: [%s]', entry.unique_id, entry.data, entry.options)
+
+    coordinator = entry.runtime_data
+    currency = entry.data[CONF_CURRENCY]
+    unit = entry.data[CONF_UNIT_OF_MEASUREMENT]
+
+    settings = SpotRateSettings(
+        currency=currency,
+        unit=unit,
+        currency_human={
+            'EUR': '€',
+            'CZK': 'Kč',
+            'USD': '$',
+        }.get(currency) or '?',
+        timezone=hass.config.time_zone,
+        zoneinfo=ZoneInfo(hass.config.time_zone),
+    )
+
+    has_tomorrow_electricity_data = HasTomorrowElectricityData(
+        hass=hass,
+        settings=settings,
+        coordinator=coordinator,
+    )
+
+    has_tomorrow_gas_data = HasTomorrowGasData(
+        hass=hass,
+        settings=settings,
+        coordinator=coordinator,
+    )
+
+    sensors = [
+        has_tomorrow_electricity_data,
+        has_tomorrow_gas_data
+    ]
+
+    for i in CONSECUTIVE_HOURS:
+        sensors.append(
+            ConsecutiveCheapestElectricitySensor(
+                hours=i,
+                hass=hass,
+                settings=settings,
+                coordinator=coordinator,
+            )
+        )
+
+    async_add_entities(sensors)
+
+    await coordinator.async_config_entry_first_refresh()
+
+
+class BinarySpotRateSensorBase(SpotRateSensorMixin, BinarySensorEntity):
+    pass
+
+
+class ConsecutiveCheapestElectricitySensor(BinarySpotRateSensorBase):
+    def __init__(self, hours: int, hass: HomeAssistant, settings: SpotRateSettings, coordinator: SpotRateCoordinator) -> None:
+        self.hours = hours
+        super().__init__(hass=hass, settings=settings, coordinator=coordinator)
+
+    @property
+    def icon(self) -> str:
+        return 'mdi:cash-clock'
+
+    @property
+    def unique_id(self) -> str:
+        if self.hours == 1:
+            return f'sensor.spot_electricity_is_cheapest'
+        else:
+            return f'sensor.spot_electricity_is_cheapest_{self.hours}_hours_block'
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        if self.hours == 1:
+            return f'Spot Electricity Is Cheapest'
+        else:
+            return f'Spot Electricity Is Cheapest {self.hours} Hours Block'
+
+    def _compute_attr(self, rate_data: SpotRateData, start: datetime, end: datetime) -> dict:
+        dt = start
+        min_price: Optional[Decimal] = None
+        max_price: Optional[Decimal] = None
+        sum_price: Decimal = Decimal(0)
+        count: int = 0
+
+        while dt <= end:
+            hour = rate_data.electricity.hour_for_dt(dt)
+            sum_price += hour.price
+            count += 1
+            if min_price is None or hour.price < min_price:
+                min_price = hour.price
+
+            if max_price is None or hour.price > max_price:
+                max_price = hour.price
+
+            dt += timedelta(hours=1)
+        return {
+            'Start': start,
+            'Start hour': start.hour,
+            'End': end,
+            'End hour': end.hour,
+            'Min': float(min_price or 0),
+            'Max': float(max_price or 0),
+            'Mean': float(sum_price / count) if count > 0 else 0,
+        }
+
+    def update(self, rate_data: Optional[SpotRateData]):
+        self._attr = {}
+        self._attr_is_on = None
+
+        if not rate_data:
+            self._available = False
+        else:
+            is_on = False
+
+            for hour in rate_data.electricity.hours_by_dt.values():
+                start = hour.dt_local - timedelta(hours=self.hours - 1)
+                end = hour.dt_local + timedelta(hours=1, seconds=-1)
+
+                # Ignore start times before now, we only want future blocks
+                if end < rate_data.electricity.now:
+                    continue
+
+                if hour.cheapest_consecutive_order[self.hours] == 1:
+                    if not self._attr:
+                        # Only put it there once, so to contains closes interval in the future
+                        self._attr = self._compute_attr(rate_data, start, end)
+
+                    if start <= rate_data.electricity.now <= end:
+                        is_on = True
+
+            self._attr_is_on = is_on
+            self._available = True
+
+
+class HasTomorrowElectricityData(BinarySpotRateSensorBase):
+    @property
+    def icon(self) -> str:
+        return 'mdi:cash-clock'
+
+    @property
+    def unique_id(self) -> str:
+        return f'sensor.spot_electricity_has_tomorrow_data'
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f'Spot Electricity Has Tomorrow Data'
+
+    def update(self, rate_data: Optional[SpotRateData]):
+        self._attr = {}
+        self._attr_is_on = None
+
+        if not rate_data:
+            self._available = False
+        else:
+            self._attr_is_on = rate_data.electricity.tomorrow is not None
+            self._available = True
+
+
+
+class HasTomorrowGasData(BinarySpotRateSensorBase):
+    @property
+    def icon(self) -> str:
+        return 'mdi:cash-clock'
+
+    @property
+    def unique_id(self) -> str:
+        return f'sensor.spot_gas_has_tomorrow_data'
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f'Spot Gas Has Tomorrow Data'
+
+    def update(self, rate_data: Optional[SpotRateData]):
+        self._attr = {}
+        self._attr_is_on = None
+
+        if not rate_data:
+            self._available = False
+        else:
+            self._attr_is_on = rate_data.gas.tomorrow is not None
+            self._available = True

--- a/custom_components/cz_energy_spot_prices/const.py
+++ b/custom_components/cz_energy_spot_prices/const.py
@@ -2,7 +2,10 @@ from homeassistant.const import Platform
 
 DOMAIN = "cz_energy_spot_prices"
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS = [
+	Platform.BINARY_SENSOR,
+	Platform.SENSOR,
+]
 
 
 ADDITIONAL_COSTS_BUY_ELECTRICITY = 'additional_costs_buy_electricity'

--- a/custom_components/cz_energy_spot_prices/sensor.py
+++ b/custom_components/cz_energy_spot_prices/sensor.py
@@ -10,11 +10,11 @@ from homeassistant.const import CONF_CURRENCY, CONF_UNIT_OF_MEASUREMENT
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.template import Template, TemplateError
 
-from .const import DOMAIN, ADDITIONAL_COSTS_SELL_ELECTRICITY, ADDITIONAL_COSTS_BUY_ELECTRICITY, ADDITIONAL_COSTS_BUY_GAS
+from . import SpotRateConfigEntry
+from .const import ADDITIONAL_COSTS_SELL_ELECTRICITY, ADDITIONAL_COSTS_BUY_ELECTRICITY, ADDITIONAL_COSTS_BUY_GAS
 from .coordinator import SpotRateCoordinator, SpotRateData, SpotRateHour, CONSECUTIVE_HOURS
 
 logger = logging.getLogger(__name__)
@@ -29,10 +29,10 @@ class Settings:
     zoneinfo: ZoneInfo
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+async def async_setup_entry(hass: HomeAssistant, entry: SpotRateConfigEntry, async_add_entities):
     logger.info('async_setup_entry %s, data: [%s] options: [%s]', entry.unique_id, entry.data, entry.options)
 
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     currency = entry.data[CONF_CURRENCY]
     unit = entry.data[CONF_UNIT_OF_MEASUREMENT]
 

--- a/custom_components/cz_energy_spot_prices/spot_rate_mixin.py
+++ b/custom_components/cz_energy_spot_prices/spot_rate_mixin.py
@@ -1,0 +1,46 @@
+import logging
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import SpotRateCoordinator, SpotRateData
+from .spot_rate_settings import SpotRateSettings
+
+logger = logging.getLogger(__name__)
+
+
+class SpotRateSensorMixin(CoordinatorEntity):
+    coordinator: SpotRateCoordinator
+
+    def __init__(self, hass: HomeAssistant, settings: SpotRateSettings, coordinator: SpotRateCoordinator):
+        super().__init__(coordinator)
+        self.hass = hass
+        self._settings = settings
+
+        self._value = None
+        self._attr = None
+        self._available = False
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.update(self.coordinator.data)
+        self.async_write_ha_state()
+
+    def update(self, rates_by_datetime: SpotRateData):
+        raise NotImplementedError()
+
+    @property
+    def native_value(self):
+        """Return the native value of the sensor."""
+        return self._value
+
+    @property
+    def extra_state_attributes(self):
+        """Return other attributes of the sensor."""
+        return self._attr
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available

--- a/custom_components/cz_energy_spot_prices/spot_rate_settings.py
+++ b/custom_components/cz_energy_spot_prices/spot_rate_settings.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from zoneinfo import ZoneInfo
+
+@dataclass
+class SpotRateSettings:
+    currency: str
+    currency_human: str
+    unit: str
+    timezone: str
+    zoneinfo: ZoneInfo

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -9,10 +9,11 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.cz_energy_spot_prices.sensor import (
-    SpotRateElectricitySensor, CurrentElectricityHourOrder, Settings, SpotRate, SpotRateCoordinator,
+    SpotRateElectricitySensor, CurrentElectricityHourOrder, SpotRateCoordinator,
     ConsecutiveCheapestElectricitySensor, TodayGasSensor, TomorrowGasSensor,
 )
 from custom_components.cz_energy_spot_prices.spot_rate import SpotRate
+from custom_components.cz_energy_spot_prices.spot_rate_settings import SpotRateSettings
 from custom_components.cz_energy_spot_prices import coordinator
 from homeassistant.core import HomeAssistant
 
@@ -65,7 +66,7 @@ class TestSensorBase:
         self.resource = resource
         self.timezone = 'Europe/Prague'
         self.hass = hass
-        self.settings = Settings(
+        self.settings = SpotRateSettings(
             currency=currency,
             unit=unit,
             currency_human={


### PR DESCRIPTION
Binární senzory musí být vytvořeny přes platformu `binary_sensor`, aby byly skutečně binární. Jejich ID pak bude začínat `binary_sensor.` a budou automaticky fungovat některé věci, např. v automatizacích se budou nabízet hodnoty Zapnuto/Vypnuto.

Původní entity jsem zatím zachoval kvůli zpětné kompatibilitě, aby se to lidem při upgradu nerozbilo.

Postavil jsem to nad https://github.com/rnovacek/homeassistant_cz_energy_spot_prices/pull/67, abych znovu nekopíroval ten starý kód do `binary_sensor`.

