### PR TITLE
Integration name can be translated too

### DIFF
--- a/custom_components/cz_energy_spot_prices/translations/cs.json
+++ b/custom_components/cz_energy_spot_prices/translations/cs.json
@@ -1,4 +1,5 @@
 {
+    "title": "Spotové ceny energií v Česku",
     "config": {
         "step": {
             "user": {

--- a/custom_components/cz_energy_spot_prices/translations/en.json
+++ b/custom_components/cz_energy_spot_prices/translations/en.json
@@ -1,4 +1,5 @@
 {
+    "title": "Czech Energy Spot Prices",
     "config": {
         "step": {
             "user": {

--- a/custom_components/cz_energy_spot_prices/translations/sk.json
+++ b/custom_components/cz_energy_spot_prices/translations/sk.json
@@ -1,4 +1,5 @@
 {
+    "title": "Spotové ceny energií v Česku",
     "config": {
         "step": {
             "user": {


### PR DESCRIPTION
`Spotové ceny energií v Česku` looks better to me than `České spotové ceny energií` however I can change it if requested.