### PR TITLE
Fix

### DIFF
--- a/custom_components/cz_energy_spot_prices/sensor.py
+++ b/custom_components/cz_energy_spot_prices/sensor.py
@@ -222,7 +222,7 @@ class HourFindSensor(PriceSensor):
             self._available = False
             self._value = None
             self._attr = {}
-            logger.info('No value found for %s', self.name)
+            logger.info('No value found for %s', self.unique_id)
             return
 
         self._available = True


### PR DESCRIPTION
It looks there can be some problem with `self.name` during entity initialization so I've modifed it to `unique_id` - it's already used in other log messages.

```
2024-11-14 12:50:54.937 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up cz_energy_spot_prices platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 365, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/config/custom_components/cz_energy_spot_prices/sensor.py", line 52, in async_setup_entry
    cheapest_tomorrow_electricity_sensor = CheapestTomorrowElectricitySensor(
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/cz_energy_spot_prices/spot_rate_mixin.py", line 26, in __init__
    self.update(self.coordinator.data)
  File "/config/custom_components/cz_energy_spot_prices/sensor.py", line 224, in update
    logger.info('No value found for %s', self.name)
                                         ^^^^^^^^^
  File "src/propcache/_helpers_c.pyx", line 88, in propcache._helpers_c.cached_property.__get__
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 727, in name
    return self._name_internal(None, {})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 683, in _name_internal
    and (name_translation_key := self._name_translation_key)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src/propcache/_helpers_c.pyx", line 88, in propcache._helpers_c.cached_property.__get__
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 646, in _name_translation_key
    f"component.{platform.platform_name}.entity.{platform.domain}"
                 ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'platform_name'
```