### PR TITLE
Improve apex chart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ series:
       in_header: raw
     data_generator: |
       return Object.entries(entity.attributes).map(([date, value], index) => {
-        return [new Date(date).getTime(), value];
+        return [new Date(date).getTime() + (30 * 60 * 1000), value];
       });
 ```
 


### PR DESCRIPTION
Add 30 minutes in the data generator to correctly place the columns in the apex chart