### PR TITLE
Fix: detect SOAP Fault element with `is not None`

### DIFF
--- a/custom_components/cz_energy_spot_prices/spot_rate.py
+++ b/custom_components/cz_energy_spot_prices/spot_rate.py
@@ -168,7 +168,7 @@ class SpotRate:
         text = await self._download(query)
         root = self._fromstring(text)
         fault = root.find(".//{http://schemas.xmlsoap.org/soap/envelope/}Fault")
-        if fault:
+        if fault is not None:
             faultstring = fault.find("faultstring")
             error = "Unknown error"
             if faultstring is not None:


### PR DESCRIPTION
`Element.__bool__()` is deprecated since Python 3.12 and returns False for elements without children, causing OTE SOAP Fault responses to be silently ignored. The downstream code then either raised `decimal.InvalidOperation` or returned empty data instead of a clear `OTEFault` exception.