### PR TITLE
Fix: preserve precision when converting CNB rate to Decimal

### DIFF
--- a/custom_components/cz_energy_spot_prices/cnb_rate.py
+++ b/custom_components/cz_energy_spot_prices/cnb_rate.py
@@ -84,7 +84,9 @@ class CnbRate:
             raise CnbRateError("Could not download CNB rates for last 7 days")
 
         for rate in cnb_rates["rates"]:
-            rates[rate["currencyCode"]] = Decimal(rate["rate"])
+            # Convert via str to preserve the precision of the source value
+            # (Decimal(float) would inherit float's binary rounding error).
+            rates[rate["currencyCode"]] = Decimal(str(rate["rate"]))
 
         return rates
 


### PR DESCRIPTION
`Decimal(float_value)` inherits the binary rounding error of the float, so e.g. `Decimal(24.315)` becomes `Decimal('24.31499999999999772...')`. Going through `str()` keeps the exact value as published by CNB API and avoids small drifts in derived spot prices.