### PR TITLE
Fix: do not overwrite FxCoordinator midnight scheduler on retry

### DIFF
--- a/custom_components/cz_energy_spot_prices/coordinator.py
+++ b/custom_components/cz_energy_spot_prices/coordinator.py
@@ -774,7 +774,13 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
                 current_delay,
             )
 
-        self._update_schedule = event.async_call_later(
+        self._retry_attempt += 1
+
+        # Schedule retry without overwriting the midnight scheduler stored in
+        # ``self._update_schedule``. Otherwise the original midnight callback
+        # would leak (its cancel handle would be lost) and we'd also lose the
+        # daily refresh after the first failure.
+        event.async_call_later(
             self.hass,
             delay=current_delay,
             action=lambda dt: self.async_request_refresh(),


### PR DESCRIPTION
On a fetch failure, `FxCoordinator._fetch_data_with_retry` overwrote `self._update_schedule` (originally holding the cancel handle for the daily midnight refresh) with the cancel handle of the retry callback. The original midnight `async_track_time_change` callback could no longer be cancelled (callback leak) and the daily refresh effectively stopped after the first failure. The retry callback no longer needs to be tracked there. Also increments `_retry_attempt` so the exponential backoff actually grows.