### PR TITLE
Use defusedxml to parse OTE responses

### DIFF
--- a/custom_components/cz_energy_spot_prices/manifest.json
+++ b/custom_components/cz_energy_spot_prices/manifest.json
@@ -11,6 +11,6 @@
   "loggers": [
     "custom_components.cz_energy_spot_prices"
   ],
-  "requirements": [],
+  "requirements": ["defusedxml>=0.7.1"],
   "version": "0.8.0"
 }

--- a/custom_components/cz_energy_spot_prices/spot_rate.py
+++ b/custom_components/cz_energy_spot_prices/spot_rate.py
@@ -4,7 +4,11 @@ from datetime import date, datetime, timedelta, time
 from zoneinfo import ZoneInfo
 from decimal import Decimal
 import asyncio
-import xml.etree.ElementTree as ET
+
+# Use defusedxml to protect against XXE / billion-laughs attacks. Even though
+# the OTE endpoint is trusted and reached via HTTPS, parsing untrusted XML with
+# the stdlib parser is discouraged by the official Python docs.
+import defusedxml.ElementTree as ET
 
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util.dt import now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ dev = [
     "pytest==9.0.0",
     "pytest-asyncio==1.3.0",
     "pytest-homeassistant-custom-component>=0.13.300",
+    # Runtime dependency declared in custom_components/.../manifest.json.
+    # Listed here so that the test environment (which does not install manifest
+    # ``requirements``) can import the integration.
+    "defusedxml>=0.7.1",
 ]
 
 [tool.pyright]

--- a/uv.lock
+++ b/uv.lock
@@ -677,6 +677,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -848,7 +857,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1047,6 +1055,7 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "defusedxml" },
     { name = "habluetooth" },
     { name = "homeassistant" },
     { name = "pillow" },
@@ -1059,6 +1068,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "habluetooth", specifier = ">=5.6.4" },
     { name = "homeassistant", specifier = ">=2025.12.2" },
     { name = "pillow", specifier = ">=11.3.0" },


### PR DESCRIPTION
The Python standard library docs explicitly recommend not using `xml.etree.ElementTree` to parse data from untrusted sources. While the OTE endpoint is trusted and reached via HTTPS, switching to `defusedxml` is a low-cost mitigation against XXE / billion-laughs / quadratic blowup attacks (e.g. in case of a compromised endpoint or MITM).