### PR TITLE
Use Home Assistant managed aiohttp session

### DIFF
--- a/custom_components/cz_energy_spot_prices/cnb_rate.py
+++ b/custom_components/cz_energy_spot_prices/cnb_rate.py
@@ -1,3 +1,5 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import date, timedelta
 from typing import TypedDict, cast
 from zoneinfo import ZoneInfo
@@ -42,16 +44,29 @@ class CnbRateError(Exception):
 class CnbRate:
     RATES_URL: str = "https://api.cnb.cz/cnbapi/exrates/daily"
 
-    def __init__(self) -> None:
+    def __init__(self, session: aiohttp.ClientSession | None = None) -> None:
         self._timezone: ZoneInfo = ZoneInfo("Europe/Prague")
         self._rates: dict[str, Decimal] = {}
         self._last_checked_date: date | None = None
+        self._session = session
+
+    @asynccontextmanager
+    async def _session_ctx(self) -> AsyncIterator[aiohttp.ClientSession]:
+        """Yield the injected session if available, otherwise create and close
+        a temporary one. Lets the rest of the code be agnostic about session
+        ownership.
+        """
+        if self._session is not None:
+            yield self._session
+            return
+        async with aiohttp.ClientSession() as session:
+            yield session
 
     async def download_rates(self, day: date) -> Rates:
         params = {"date": day.isoformat()}
 
         text: Rates
-        async with aiohttp.ClientSession() as session:
+        async with self._session_ctx() as session:
             async with session.get(self.RATES_URL, params=params) as response:
                 if response.status > 299:
                     if response.status == 400:

--- a/custom_components/cz_energy_spot_prices/coordinator.py
+++ b/custom_components/cz_energy_spot_prices/coordinator.py
@@ -12,6 +12,7 @@ import async_timeout
 
 from attr import dataclass
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.update_coordinator import (
@@ -457,7 +458,7 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
             name=f"Czech Energy Spot Prices [SpotRateCoordinator] for {commodity}",
         )
         self.hass = hass
-        self._spot_rate = SpotRate()
+        self._spot_rate = SpotRate(session=async_get_clientsession(hass))
         self._spot_rate_data: RatesByInterval | None = None
         self._update_schedule = None
         self._retry_attempt = 0
@@ -768,7 +769,7 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
             name="Czech Energy Spot Prices [FxCoordinator]",
         )
 
-        self._cnb = CnbRate()
+        self._cnb = CnbRate(session=async_get_clientsession(hass))
         self._retry_attempt = 0
 
         # Update on midnight local (hass) time

--- a/custom_components/cz_energy_spot_prices/spot_rate.py
+++ b/custom_components/cz_energy_spot_prices/spot_rate.py
@@ -1,5 +1,7 @@
 import sys
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import date, datetime, timedelta, time
 from zoneinfo import ZoneInfo
 from decimal import Decimal
@@ -93,9 +95,10 @@ class SpotRate:
     OTE_PUBLIC_URL = "https://www.ote-cr.cz/services/PublicDataService"
     UNIT = "MWh"
 
-    def __init__(self):
+    def __init__(self, session: aiohttp.ClientSession | None = None):
         self.timezone = ZoneInfo("Europe/Prague")
         self.utc = ZoneInfo("UTC")
+        self._session = session
 
     def get_electricity_query(
         self,
@@ -109,9 +112,21 @@ class SpotRate:
     def get_gas_query(self, start: date, end: date) -> str:
         return QUERY_GAS.format(start=start.isoformat(), end=end.isoformat())
 
+    @asynccontextmanager
+    async def _session_ctx(self) -> AsyncIterator[aiohttp.ClientSession]:
+        """Yield the injected session if available, otherwise create and close
+        a temporary one. Lets the rest of the code be agnostic about session
+        ownership.
+        """
+        if self._session is not None:
+            yield self._session
+            return
+        async with aiohttp.ClientSession() as session:
+            yield session
+
     async def _download(self, query: str) -> str:
         try:
-            async with aiohttp.ClientSession() as session:
+            async with self._session_ctx() as session:
                 async with session.post(self.OTE_PUBLIC_URL, data=query) as response:
                     if response.status > 299:
                         raise OTEFault(


### PR DESCRIPTION
Both `SpotRate` and `CnbRate` previously created a fresh `aiohttp.ClientSession` on every call. This bypasses Home Assistant's connection pooling, forces a new TCP/TLS handshake per request, and never explicitly closes the session (relying on garbage collection, which can produce `Unclosed client session` warnings).

The coordinators now obtain the shared session via `async_get_clientsession(hass)` and pass it in. The standalone fallback (used when running these modules directly with `python -m`) is preserved for ad-hoc debugging.