### PR TITLE
Format invalid-commodity error message correctly

### DIFF
--- a/custom_components/cz_energy_spot_prices/__init__.py
+++ b/custom_components/cz_energy_spot_prices/__init__.py
@@ -161,7 +161,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEnt
 
         interval = SpotRateIntervalType.Day
     else:
-        raise ValueError("Invalid commodity: %s", commodity)
+        raise ValueError(f"Invalid commodity: {commodity}")
 
     if currency != Currency.EUR:
         fx_coordinator: FxCoordinator | None = domain_data.get(FX_COORDINATOR)


### PR DESCRIPTION
`ValueError` does not perform `%` formatting on its arguments. The previous call `ValueError(\"Invalid commodity: %s\", commodity)` produced an exception with two args (the format string and the value), so `str(exc)` rendered them as a tuple instead of the intended message.