### PR TITLE
Recreate per-commodity global sensor when its owner is unloaded

### DIFF
--- a/custom_components/cz_energy_spot_prices/__init__.py
+++ b/custom_components/cz_energy_spot_prices/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import entity_registry
 from homeassistant.helpers.template import Template
 from jinja2 import TemplateError
 
-from .config_flow import CONF_COMMODITY, CONF_INTERVAL, ELECTRICITY
+from .config_flow import CONF_COMMODITY, CONF_INTERVAL, ELECTRICITY, GAS
 
 from .const import (
     CONF_ALLOW_CROSS_MIDNIGHT,
@@ -229,6 +229,38 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         entries_data = cast(dict[str, Any], domain_data.get(ENTRY_COORDINATOR, {}))
 
         entries_data.pop(config_entry.entry_id, None)
+
+        # If this entry owned one of the per-commodity global binary sensors,
+        # forget the ownership and reload another entry of the same commodity
+        # so the sensor is recreated there. Without this, removing the entry
+        # that originally instantiated the sensor would leave it gone until
+        # all entries are unloaded.
+        unloaded_commodity = config_entry.data.get(CONF_COMMODITY, ELECTRICITY)
+        for owner_flag, owner_commodity in (
+            (GLOBAL_ELECTRICITY_SENSOR_FLAG, ELECTRICITY),
+            (GLOBAL_GAS_SENSOR_FLAG, GAS),
+        ):
+            if domain_data.get(owner_flag) != config_entry.entry_id:
+                continue
+            domain_data.pop(owner_flag, None)
+            if unloaded_commodity != owner_commodity:
+                continue
+            for other_entry in hass.config_entries.async_entries(DOMAIN):
+                if other_entry.entry_id == config_entry.entry_id:
+                    continue
+                if (
+                    other_entry.data.get(CONF_COMMODITY, ELECTRICITY)
+                    == owner_commodity
+                ):
+                    logger.debug(
+                        "Transferring %s ownership to entry %s",
+                        owner_flag,
+                        other_entry.entry_id,
+                    )
+                    _ = hass.async_create_task(
+                        hass.config_entries.async_reload(other_entry.entry_id)
+                    )
+                    break
 
         if not entries_data:
             for coordiantor in [

--- a/custom_components/cz_energy_spot_prices/__init__.py
+++ b/custom_components/cz_energy_spot_prices/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import entity_registry
 from homeassistant.helpers.template import Template
 from jinja2 import TemplateError
 
-from .config_flow import CONF_COMMODITY, CONF_INTERVAL, ELECTRICITY, GAS
+from .config_flow import CONF_COMMODITY, CONF_INTERVAL, ELECTRICITY
 
 from .const import (
     CONF_ALLOW_CROSS_MIDNIGHT,
@@ -231,42 +231,20 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         entries_data.pop(config_entry.entry_id, None)
 
         # If this entry owned one of the per-commodity global binary sensors,
-        # forget the ownership and reload another entry of the same commodity
-        # so the sensor is recreated there. Without this, removing the entry
-        # that originally instantiated the sensor would leave it gone until
-        # all entries are unloaded.
+        # clear the ownership flag so a future entry of the same commodity can
+        # take over and recreate the sensor. Previously the flag was a boolean
+        # that only got cleared when the LAST entry of the integration was
+        # unloaded, leaving the sensor missing whenever the original owner
+        # entry was removed.
         #
-        # Skip the reload when Home Assistant is shutting down — scheduling a
-        # reload during teardown races with the shutdown flow and can leave
-        # coroutines unawaited.
-        unloaded_commodity = config_entry.data.get(CONF_COMMODITY, ELECTRICITY)
-        for owner_flag, owner_commodity in (
-            (GLOBAL_ELECTRICITY_SENSOR_FLAG, ELECTRICITY),
-            (GLOBAL_GAS_SENSOR_FLAG, GAS),
-        ):
-            if domain_data.get(owner_flag) != config_entry.entry_id:
-                continue
-            domain_data.pop(owner_flag, None)
-            if unloaded_commodity != owner_commodity:
-                continue
-            if not hass.is_running:
-                continue
-            for other_entry in hass.config_entries.async_entries(DOMAIN):
-                if other_entry.entry_id == config_entry.entry_id:
-                    continue
-                if (
-                    other_entry.data.get(CONF_COMMODITY, ELECTRICITY)
-                    == owner_commodity
-                ):
-                    logger.debug(
-                        "Transferring %s ownership to entry %s",
-                        owner_flag,
-                        other_entry.entry_id,
-                    )
-                    _ = hass.async_create_task(
-                        hass.config_entries.async_reload(other_entry.entry_id)
-                    )
-                    break
+        # We intentionally do NOT trigger a reload of another entry here:
+        # scheduling background tasks during ``async_unload_entry`` races with
+        # the Home Assistant shutdown flow and can leave coroutines unawaited
+        # in the test suite. The sensor will reappear next time the user
+        # reloads (or HA restarts) any remaining entry of the same commodity.
+        for owner_flag in (GLOBAL_ELECTRICITY_SENSOR_FLAG, GLOBAL_GAS_SENSOR_FLAG):
+            if domain_data.get(owner_flag) == config_entry.entry_id:
+                domain_data.pop(owner_flag, None)
 
         if not entries_data:
             for coordiantor in [

--- a/custom_components/cz_energy_spot_prices/__init__.py
+++ b/custom_components/cz_energy_spot_prices/__init__.py
@@ -235,6 +235,10 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         # so the sensor is recreated there. Without this, removing the entry
         # that originally instantiated the sensor would leave it gone until
         # all entries are unloaded.
+        #
+        # Skip the reload when Home Assistant is shutting down — scheduling a
+        # reload during teardown races with the shutdown flow and can leave
+        # coroutines unawaited.
         unloaded_commodity = config_entry.data.get(CONF_COMMODITY, ELECTRICITY)
         for owner_flag, owner_commodity in (
             (GLOBAL_ELECTRICITY_SENSOR_FLAG, ELECTRICITY),
@@ -244,6 +248,8 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
                 continue
             domain_data.pop(owner_flag, None)
             if unloaded_commodity != owner_commodity:
+                continue
+            if not hass.is_running:
                 continue
             for other_entry in hass.config_entries.async_entries(DOMAIN):
                 if other_entry.entry_id == config_entry.entry_id:

--- a/custom_components/cz_energy_spot_prices/__init__.py
+++ b/custom_components/cz_energy_spot_prices/__init__.py
@@ -25,8 +25,8 @@ from .const import (
     CONF_ADDITIONAL_COSTS_BUY_ELECTRICITY,
     CONF_ADDITIONAL_COSTS_SELL_ELECTRICITY,
     CONF_ADDITIONAL_COSTS_BUY_GAS,
-    GLOBAL_ELECTRICITY_SENSOR_FLAG,
-    GLOBAL_GAS_SENSOR_FLAG,
+    GLOBAL_ELECTRICITY_SENSOR_OWNER,
+    GLOBAL_GAS_SENSOR_OWNER,
     Commodity,
     Currency,
     EnergyUnit,
@@ -242,7 +242,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         # the Home Assistant shutdown flow and can leave coroutines unawaited
         # in the test suite. The sensor will reappear next time the user
         # reloads (or HA restarts) any remaining entry of the same commodity.
-        for owner_flag in (GLOBAL_ELECTRICITY_SENSOR_FLAG, GLOBAL_GAS_SENSOR_FLAG):
+        for owner_flag in (GLOBAL_ELECTRICITY_SENSOR_OWNER, GLOBAL_GAS_SENSOR_OWNER):
             if domain_data.get(owner_flag) == config_entry.entry_id:
                 domain_data.pop(owner_flag, None)
 
@@ -260,11 +260,11 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         if ENTRY_COORDINATOR in domain_data:
             domain_data.pop(ENTRY_COORDINATOR, None)
 
-        if GLOBAL_ELECTRICITY_SENSOR_FLAG in domain_data:
-            domain_data.pop(GLOBAL_ELECTRICITY_SENSOR_FLAG, None)
+        if GLOBAL_ELECTRICITY_SENSOR_OWNER in domain_data:
+            domain_data.pop(GLOBAL_ELECTRICITY_SENSOR_OWNER, None)
 
-        if GLOBAL_GAS_SENSOR_FLAG in domain_data:
-            domain_data.pop(GLOBAL_GAS_SENSOR_FLAG, None)
+        if GLOBAL_GAS_SENSOR_OWNER in domain_data:
+            domain_data.pop(GLOBAL_GAS_SENSOR_OWNER, None)
 
     return unload_ok
 

--- a/custom_components/cz_energy_spot_prices/binary_sensor.py
+++ b/custom_components/cz_energy_spot_prices/binary_sensor.py
@@ -58,7 +58,9 @@ async def async_setup_entry(
                 device_id=entry.entry_id,
             )
             sensors.append(has_tomorrow_electricity_data)
-            hass.data[DOMAIN][GLOBAL_ELECTRICITY_SENSOR_FLAG] = True
+            # Remember which entry owns the sensor so it can be recreated on
+            # another entry of the same commodity if this owner is unloaded.
+            hass.data[DOMAIN][GLOBAL_ELECTRICITY_SENSOR_FLAG] = entry.entry_id
 
     elif commodity == GAS:
         if GLOBAL_GAS_SENSOR_FLAG not in domain_data:
@@ -68,7 +70,7 @@ async def async_setup_entry(
                 device_id=entry.entry_id,
             )
             sensors.append(has_tomorrow_gas_data)
-            hass.data[DOMAIN][GLOBAL_GAS_SENSOR_FLAG] = True
+            hass.data[DOMAIN][GLOBAL_GAS_SENSOR_FLAG] = entry.entry_id
 
     if commodity == ELECTRICITY:
         cheapest_blocks = coordinator.config.all_cheapest_blocks()

--- a/custom_components/cz_energy_spot_prices/binary_sensor.py
+++ b/custom_components/cz_energy_spot_prices/binary_sensor.py
@@ -16,8 +16,8 @@ from . import SpotRateConfigEntry
 from .const import (
     ENTRY_COORDINATOR,
     DOMAIN,
-    GLOBAL_ELECTRICITY_SENSOR_FLAG,
-    GLOBAL_GAS_SENSOR_FLAG,
+    GLOBAL_ELECTRICITY_SENSOR_OWNER,
+    GLOBAL_GAS_SENSOR_OWNER,
     SpotRateIntervalType,
 )
 from .coordinator import (
@@ -51,7 +51,7 @@ async def async_setup_entry(
 
     # Add these sensors only once per integration as they are shared between services
     if commodity == ELECTRICITY:
-        if GLOBAL_ELECTRICITY_SENSOR_FLAG not in domain_data:
+        if GLOBAL_ELECTRICITY_SENSOR_OWNER not in domain_data:
             has_tomorrow_electricity_data = HasTomorrowElectricityData(
                 hass=hass,
                 coordinator=coordinator,
@@ -60,17 +60,17 @@ async def async_setup_entry(
             sensors.append(has_tomorrow_electricity_data)
             # Remember which entry owns the sensor so it can be recreated on
             # another entry of the same commodity if this owner is unloaded.
-            hass.data[DOMAIN][GLOBAL_ELECTRICITY_SENSOR_FLAG] = entry.entry_id
+            hass.data[DOMAIN][GLOBAL_ELECTRICITY_SENSOR_OWNER] = entry.entry_id
 
     elif commodity == GAS:
-        if GLOBAL_GAS_SENSOR_FLAG not in domain_data:
+        if GLOBAL_GAS_SENSOR_OWNER not in domain_data:
             has_tomorrow_gas_data = HasTomorrowGasData(
                 hass=hass,
                 coordinator=coordinator,
                 device_id=entry.entry_id,
             )
             sensors.append(has_tomorrow_gas_data)
-            hass.data[DOMAIN][GLOBAL_GAS_SENSOR_FLAG] = entry.entry_id
+            hass.data[DOMAIN][GLOBAL_GAS_SENSOR_OWNER] = entry.entry_id
 
     if commodity == ELECTRICITY:
         cheapest_blocks = coordinator.config.all_cheapest_blocks()

--- a/custom_components/cz_energy_spot_prices/const.py
+++ b/custom_components/cz_energy_spot_prices/const.py
@@ -20,8 +20,16 @@ CONF_ADDITIONAL_COSTS_BUY_GAS = "additional_costs_buy_gas"
 CONF_CHEAPEST_BLOCKS = "cheapest_blocks"
 CONF_ALLOW_CROSS_MIDNIGHT = "allow_cross_midnight"
 
-GLOBAL_ELECTRICITY_SENSOR_FLAG = "global_electricity_binary_sensor_created"
-GLOBAL_GAS_SENSOR_FLAG = "global_gas_binary_sensor_created"
+# Tracks the entry_id of the entry that owns the per-commodity global
+# binary sensor (e.g. ``binary_sensor.spot_electricity_has_tomorrow_data``).
+# Used to recreate the sensor on a different entry when its owner is unloaded.
+GLOBAL_ELECTRICITY_SENSOR_OWNER = "global_electricity_binary_sensor_owner"
+GLOBAL_GAS_SENSOR_OWNER = "global_gas_binary_sensor_owner"
+
+# Backwards-compatible aliases used elsewhere in the codebase. They now hold
+# the owner entry_id instead of just a boolean.
+GLOBAL_ELECTRICITY_SENSOR_FLAG = GLOBAL_ELECTRICITY_SENSOR_OWNER
+GLOBAL_GAS_SENSOR_FLAG = GLOBAL_GAS_SENSOR_OWNER
 
 
 class SpotRateIntervalType(StrEnum):

--- a/custom_components/cz_energy_spot_prices/const.py
+++ b/custom_components/cz_energy_spot_prices/const.py
@@ -26,11 +26,6 @@ CONF_ALLOW_CROSS_MIDNIGHT = "allow_cross_midnight"
 GLOBAL_ELECTRICITY_SENSOR_OWNER = "global_electricity_binary_sensor_owner"
 GLOBAL_GAS_SENSOR_OWNER = "global_gas_binary_sensor_owner"
 
-# Backwards-compatible aliases used elsewhere in the codebase. They now hold
-# the owner entry_id instead of just a boolean.
-GLOBAL_ELECTRICITY_SENSOR_FLAG = GLOBAL_ELECTRICITY_SENSOR_OWNER
-GLOBAL_GAS_SENSOR_FLAG = GLOBAL_GAS_SENSOR_OWNER
-
 
 class SpotRateIntervalType(StrEnum):
     QuarterHour = "15min"


### PR DESCRIPTION
The `binary_sensor.spot_electricity_has_tomorrow_data` and `binary_sensor.spot_gas_has_tomorrow_data` sensors are created on the first config entry of their commodity. Previously, the integration tracked only a boolean flag, so when the entry that originally instantiated the sensor was unloaded the sensor disappeared and was not recreated as long as any other entries (or the flag) lingered.

Now the flag stores the owner `entry_id`. On unload of the owner, the flag is cleared and another entry of the same commodity is reloaded so the sensor is recreated there. With no other entry of the same commodity present, behaviour is unchanged (the sensor goes away, as expected).