### PR TITLE
Remove dead in_eur kwarg from electricity query format

### DIFF
--- a/custom_components/cz_energy_spot_prices/spot_rate.py
+++ b/custom_components/cz_energy_spot_prices/spot_rate.py
@@ -99,7 +99,7 @@ class SpotRate:
         end: date,
     ) -> str:
         return QUERY_ELECTRICITY.format(
-            start=start.isoformat(), end=end.isoformat(), in_eur="true"
+            start=start.isoformat(), end=end.isoformat()
         )
 
     def get_gas_query(self, start: date, end: date) -> str:


### PR DESCRIPTION
QUERY_ELECTRICITY does not contain an in_eur placeholder, so passing in_eur='true' to str.format was a no-op left over from a previous refactor.