### PR TITLE
Remove dead commented-out code

### DIFF
--- a/custom_components/cz_energy_spot_prices/coordinator.py
+++ b/custom_components/cz_energy_spot_prices/coordinator.py
@@ -88,10 +88,6 @@ class SpotRateInterval:
 
         self.most_expensive_order = 0
 
-        # self.consecutive_sum_prices: dict[int, Decimal] = {}
-
-        # self.cheapest_consecutive_order: dict[int, int] = {}
-
     @override
     def __repr__(self):
         return f"<{self.dt_utc}: {self.price}>"
@@ -222,43 +218,6 @@ class IntervalSpotRateData:
                     logger.error("Unable to find cheapest interval")
                 else:
                     logger.error("Unable to find cheapest %s hour block", block)
-
-            # for base_dt, rate_interval in self.interval_by_dt.items():
-            #     rate = Decimal(0)
-            #     for offset in range(config.cheapest_blocks[-1]):
-            #         prev_dt = base_dt - timedelta(hours=offset)
-            #         prev_hour = self.interval_by_dt.get(prev_dt)
-            #         if not prev_hour:
-            #             # Out of range, probably before yesterday
-            #             continue
-
-            #         rate += prev_hour.price
-
-            #         if (offset + 1) in config.cheapest_blocks:
-            #             rate_interval.consecutive_sum_prices[(offset + 1)] = rate
-
-            # if not self.today_day:
-            #     return
-
-            # for consecutive in config.cheapest_blocks:
-            #     sorted_today_hours = sorted(
-            #         self.today_day.interval_by_dt.values(),
-            #         key=lambda hour: hour.consecutive_sum_prices.get(
-            #             consecutive, Decimal(0)
-            #         ),
-            #     )
-            #     for i, rate_interval in enumerate(sorted_today_hours, 1):
-            #         rate_interval.cheapest_consecutive_order[consecutive] = i
-
-            #     if self.tomorrow_day is not None:
-            #         sorted_tomorrow_hours = sorted(
-            #             self.tomorrow_day.interval_by_dt.values(),
-            #             key=lambda hour: hour.consecutive_sum_prices.get(
-            #                 consecutive, Decimal(0)
-            #             ),
-            #         )
-            #         for i, rate_interval in enumerate(sorted_tomorrow_hours, 1):
-            #             rate_interval.cheapest_consecutive_order[consecutive] = i
 
     def interval_for_dt(self, dt: datetime) -> SpotRateInterval:
         if self.config.interval == SpotRateIntervalType.Day:
@@ -497,9 +456,6 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
         self._retry_attempt = 0
         self._commodity = commodity
         self._next_update: datetime | None = None
-
-        # TODO: persist data using
-        # self._store = storage.Store(hass, STORAGE_VERSION, STORAGE_KEY)
 
     def _schedule_next_update(self):
         # OTE prices are published at 13:02 CE(S)T time - we need to make that independent on HA timezone,

--- a/custom_components/cz_energy_spot_prices/spot_rate.py
+++ b/custom_components/cz_energy_spot_prices/spot_rate.py
@@ -303,10 +303,7 @@ if __name__ == "__main__":
         else:
             hour = ""
         print(f"{dt.isoformat():30s} {eur:10.4f} {czk:10.4f} {hour}")
-    # rates_eur = asyncio.run(spot_rate.get_gas_rates(dt, in_eur=True, unit='kWh'))
-    # rates_czk = asyncio.run(spot_rate.get_gas_rates(dt, in_eur=False, unit='kWh'))
 
     print("GAS")
     gas_rates = asyncio.run(spot_rate.get_gas_rates(dt))
     print(gas_rates)
-    # print_rates(rates_eur, rates_czk)


### PR DESCRIPTION
Removes a few stale code blocks that were left commented out:

- Two unused attribute placeholders in `SpotRateInterval.__init__`.
- A large commented-out alternative implementation of consecutive-block computation in `IntervalSpotRateData`.
- A `TODO: persist data using Store` comment in `SpotRateCoordinator.__init__`.
- Two leftover commented call examples in the `__main__` block of `spot_rate`.