### PR TITLE
Rename module-level logger to _LOGGER for HA style consistency

### DIFF
--- a/custom_components/cz_energy_spot_prices/__init__.py
+++ b/custom_components/cz_energy_spot_prices/__init__.py
@@ -40,13 +40,13 @@ from .coordinator import (
 )
 
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 type SpotRateConfigEntry = ConfigEntry[EntryCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEntry):
-    logger.debug(
+    _LOGGER.debug(
         "async_setup_entry %s data: [%s]; options: [%s]",
         config_entry.unique_id,
         config_entry.data,
@@ -89,7 +89,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEnt
             try:
                 buy_template = Template(buy_template_config, hass=hass)
             except TemplateError as e:
-                logger.error(
+                _LOGGER.error(
                     "Invalid template for electricity buy price: %s\n%s",
                     e,
                     buy_template_config,
@@ -102,7 +102,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEnt
             try:
                 sell_template = Template(sell_template_config, hass=hass)
             except TemplateError as e:
-                logger.error(
+                _LOGGER.error(
                     "Invalid template for electricity sell price: %s\n%s",
                     e,
                     sell_template_config,
@@ -123,7 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEnt
                     [int(block) for block in cheapest_blocks_conf.split(",")]
                 )
             except ValueError:
-                logger.error(
+                _LOGGER.error(
                     "Invalid config for cheapest_blocks: %s", cheapest_blocks_conf
                 )
         else:
@@ -153,7 +153,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEnt
             try:
                 buy_template = Template(gas_buy_template_config, hass=hass)
             except TemplateError as e:
-                logger.error(
+                _LOGGER.error(
                     "Invalid template for gas buy price: %s\n%s",
                     e,
                     gas_buy_template_config,
@@ -219,7 +219,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEnt
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Unload config entry."""
-    logger.debug("async_unload_entry %s", config_entry.unique_id)
+    _LOGGER.debug("async_unload_entry %s", config_entry.unique_id)
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
     )
@@ -295,7 +295,7 @@ async def _migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
         )
 
         if entity_id:
-            logger.info(
+            _LOGGER.info(
                 "Migrating %s unique_id %s → %s",
                 entity_id,
                 old_unique_id,
@@ -304,13 +304,13 @@ async def _migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
             try:
                 _ = ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
             except ValueError as e:
-                logger.info(
+                _LOGGER.info(
                     "Unable to rename entity %s to %s: %s", entity_id, new_unique_id, e
                 )
             migrated += 1
 
     if migrated:
-        logger.info("Migrated %s entities from old unique_id format.", migrated)
+        _LOGGER.info("Migrated %s entities from old unique_id format.", migrated)
 
     deprecated_ids = [
         "sensor.spot_electricity_is_cheapest",
@@ -334,4 +334,4 @@ async def _migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
         )
         if entity_id:
             ent_reg.async_remove(entity_id)
-            logger.info("Deprecated entity %s removed", entity_id)
+            _LOGGER.info("Deprecated entity %s removed", entity_id)

--- a/custom_components/cz_energy_spot_prices/binary_sensor.py
+++ b/custom_components/cz_energy_spot_prices/binary_sensor.py
@@ -27,7 +27,7 @@ from .coordinator import (
 )
 from .spot_rate_mixin import SpotRateSensorMixin, Trade
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -35,7 +35,7 @@ async def async_setup_entry(
     entry: SpotRateConfigEntry,
     async_add_entities: Callable[[list[Entity]], None],
 ) -> None:
-    logger.debug(
+    _LOGGER.debug(
         "binary_sensor.async_setup_entry %s, data: [%s] options: [%s]",
         entry.unique_id,
         entry.data,
@@ -184,9 +184,9 @@ class ConsecutiveCheapestElectricitySensor(BinarySpotRateSensorBase):
             window = trade_rates.cheapest_windows[self.hours]
         except KeyError:
             if self.hours is None:
-                logger.error("Unable to find cheapest interval")
+                _LOGGER.error("Unable to find cheapest interval")
             else:
-                logger.error("Unable to find cheapest %s hour block", self.hours)
+                _LOGGER.error("Unable to find cheapest %s hour block", self.hours)
             self._attr_available = False
             return
 

--- a/custom_components/cz_energy_spot_prices/config_flow.py
+++ b/custom_components/cz_energy_spot_prices/config_flow.py
@@ -27,7 +27,7 @@ from .const import (
 )
 
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 UNITS = {
     "kWh": "kWh",
@@ -188,7 +188,7 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
         self, user_input: dict[str, Any] | None = None
     ):  # -> FlowResult:
         """Manage the options."""
-        logger.debug(
+        _LOGGER.debug(
             f"OptionsFlowHandler:async_step_init user_input [{user_input}] data [{self.config_entry.data}] options [{self.config_entry.options}]"
         )
 

--- a/custom_components/cz_energy_spot_prices/coordinator.py
+++ b/custom_components/cz_energy_spot_prices/coordinator.py
@@ -29,7 +29,7 @@ from .spot_rate import (
     OTEFault,
 )
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 PRAGUE_TZ = ZoneInfo("Europe/Prague")
 
@@ -60,11 +60,11 @@ class EntryConfig:
             try:
                 block = int(block)
             except ValueError:
-                logger.error("Invalid interval for cheapest blocks: %s", block)
+                _LOGGER.error("Invalid interval for cheapest blocks: %s", block)
                 continue
 
             if block < 1 or block > 23:
-                logger.error("Invalid interval for cheapest blocks: %s", block)
+                _LOGGER.error("Invalid interval for cheapest blocks: %s", block)
                 continue
 
             if block == 1 and self.interval == SpotRateIntervalType.Hour:
@@ -219,9 +219,9 @@ class IntervalSpotRateData:
                 self.cheapest_windows[block] = window
             except ValueError:
                 if block is None:
-                    logger.error("Unable to find cheapest interval")
+                    _LOGGER.error("Unable to find cheapest interval")
                 else:
-                    logger.error("Unable to find cheapest %s hour block", block)
+                    _LOGGER.error("Unable to find cheapest %s hour block", block)
 
             # for base_dt, rate_interval in self.interval_by_dt.items():
             #     rate = Decimal(0)
@@ -484,10 +484,10 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
         hass: HomeAssistant,
         commodity: Commodity,
     ):
-        logger.debug("SpotRateCoordinator[%s].__init__", commodity)
+        _LOGGER.debug("SpotRateCoordinator[%s].__init__", commodity)
         super().__init__(
             hass,
-            logger,
+            _LOGGER,
             name=f"Czech Energy Spot Prices [SpotRateCoordinator] for {commodity}",
         )
         self.hass = hass
@@ -543,14 +543,14 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
 
     async def async_stop(self):
         """Cancel scheduled jobs."""
-        logger.debug("SpotRateCoordinator[%s].async_stop", self._commodity)
+        _LOGGER.debug("SpotRateCoordinator[%s].async_stop", self._commodity)
         if self._update_schedule:
             self._update_schedule()
             self._update_schedule = None
 
     @callback
     def on_schedule(self, dt: datetime):
-        logger.debug(
+        _LOGGER.debug(
             "SpotRateCoordinator[%s].on_schedule called at %s", self._commodity, dt
         )
 
@@ -561,7 +561,7 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
         _ = self.hass.async_create_task(self.async_request_refresh())
 
     async def _fetch_data(self):
-        logger.debug("SpotRateCoordinator[%s]._fetch_data", self._commodity)
+        _LOGGER.debug("SpotRateCoordinator[%s]._fetch_data", self._commodity)
 
         zoneinfo = ZoneInfo(self.hass.config.time_zone)
         start = now(zoneinfo)
@@ -578,7 +578,7 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
     async def _fetch_data_with_retry(self):
         is_first_run = self.data is None
 
-        logger.debug("SpotRateCoordinator[%s]._fetch_data_with_retry", self._commodity)
+        _LOGGER.debug("SpotRateCoordinator[%s]._fetch_data_with_retry", self._commodity)
         current_delay = cast(int, 2**self._retry_attempt)
         try:
             async with async_timeout.timeout(30):
@@ -587,14 +587,14 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
                 return data
 
         except (OTEFault, aiohttp.client_exceptions.ClientError, asyncio.TimeoutError) as e:
-            logger.warning(
+            _LOGGER.warning(
                 "Failed to update OTE prices, will retry in %d seconds: %s",
                 current_delay,
                 e,
             )
 
         except Exception:
-            logger.exception(
+            _LOGGER.exception(
                 "OTE request failed unexpectedly, will retry in %d seconds",
                 current_delay,
             )
@@ -650,7 +650,7 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
             self._update_schedule = None
 
         if point_in_time is not None:
-            logger.debug(
+            _LOGGER.debug(
                 "SpotRateCoordinator[%s] scheduling update at %s",
                 self._commodity,
                 point_in_time,
@@ -662,7 +662,7 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
             )
             self._next_update = point_in_time
         elif delay is not None:
-            logger.debug(
+            _LOGGER.debug(
                 "SpotRateCoordinator[%s] scheduling update in %s seconds",
                 self._commodity,
                 delay,
@@ -684,7 +684,7 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
         so entities can quickly look up their data.
         """
 
-        logger.debug("SpotRateCoordinator[%s]._async_update_data", self._commodity)
+        _LOGGER.debug("SpotRateCoordinator[%s]._async_update_data", self._commodity)
 
         self._spot_rate_data = await self._fetch_data_with_retry()
         if self._spot_rate_data is None:
@@ -693,7 +693,7 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
 
         if not self.has_tomorrow_data() and self.is_tomorrow_data_available():
             # Tomorrow data should be available but are not => schedule update soon
-            logger.info(
+            _LOGGER.info(
                 "SpotRateCoordinator[%s] tomorrow data should be available in OTE but are not => rescheduling in 2 minutes",
                 self._commodity,
             )
@@ -702,7 +702,7 @@ class SpotRateCoordinator(DataUpdateCoordinator[RatesByInterval | None]):
         else:
             # Schedule the update for tommorow
             dt = self._schedule_next_update()
-            logger.info(
+            _LOGGER.info(
                 "SpotRateCoordinator[%s] data updated, scheduling next update at %s",
                 self._commodity,
                 dt,
@@ -719,7 +719,7 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
         """Initialize my coordinator."""
         super().__init__(
             hass,
-            logger,
+            _LOGGER,
             name="Czech Energy Spot Prices [FxCoordinator]",
         )
 
@@ -738,7 +738,7 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
     async def async_stop(self):
         """Cancel scheduled jobs."""
         if self._update_schedule:
-            logger.debug("Unscheduling FX coordinator")
+            _LOGGER.debug("Unscheduling FX coordinator")
             self._update_schedule()
             self._update_schedule = None
 
@@ -747,13 +747,13 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
         _ = self.hass.async_create_task(self.async_request_refresh())
 
     async def _fetch_data(self):
-        logger.debug("FxCoordinator._fetch_data")
+        _LOGGER.debug("FxCoordinator._fetch_data")
 
         rates = await self._cnb.get_current_rates()
         return rates
 
     async def _fetch_data_with_retry(self):
-        logger.debug("FxCoordinator._fetch_data_with_retry")
+        _LOGGER.debug("FxCoordinator._fetch_data_with_retry")
         current_delay = cast(int, 2**self._retry_attempt)
         try:
             async with async_timeout.timeout(30):
@@ -762,14 +762,14 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
                 return data
 
         except (OTEFault, aiohttp.client_exceptions.ClientError, asyncio.TimeoutError) as e:
-            logger.warning(
+            _LOGGER.warning(
                 "Failed to update CNB FX rates, will retry in %d seconds: %s",
                 current_delay,
                 e,
             )
 
         except Exception:
-            logger.exception(
+            _LOGGER.exception(
                 "CNB FX request failed unexpectedly, will retry in %d seconds",
                 current_delay,
             )
@@ -811,7 +811,7 @@ class EntryCoordinator(DataUpdateCoordinator[IntervalTradeRateData | None]):
 
         super().__init__(
             hass,
-            logger,
+            _LOGGER,
             name=f"Czech Energy Spot Prices [EntryCoordinator {config.unit, config.currency, config.commodity, config.interval}]",
         )
 
@@ -838,7 +838,7 @@ class EntryCoordinator(DataUpdateCoordinator[IntervalTradeRateData | None]):
     @callback
     def _source_updated(self):
         """When spot or FX data updates → recompute derived data."""
-        logger.debug(
+        _LOGGER.debug(
             "EntryCoordinator [%s] update by fx or spot rate change",
             self._config,
         )
@@ -848,27 +848,27 @@ class EntryCoordinator(DataUpdateCoordinator[IntervalTradeRateData | None]):
 
     def _compute_data(self):
         if not self._spot_coordinator.data:
-            logger.debug("Spot rate data not available")
+            _LOGGER.debug("Spot rate data not available")
             return None
         spot_rates = self._spot_coordinator.data
 
         fx_rate = Decimal(1)
         if self._fx_coordinator:
             if not self._fx_coordinator.data:
-                logger.debug("Currency rates not available")
+                _LOGGER.debug("Currency rates not available")
                 return None
 
             fx_rates = self._fx_coordinator.data
             eur_rate = fx_rates.get("EUR")
             if eur_rate is None:
-                logger.warning(
+                _LOGGER.warning(
                     "Unable to find conversion rate for EUR, skipping update to avoid publishing incorrect prices"
                 )
                 return None
 
             currency_rate = fx_rates.get(self._config.currency)
             if currency_rate is None:
-                logger.warning(
+                _LOGGER.warning(
                     "Unable to find conversion rate for %s, skipping update to avoid publishing incorrect prices",
                     self._config.currency,
                 )

--- a/custom_components/cz_energy_spot_prices/sensor.py
+++ b/custom_components/cz_energy_spot_prices/sensor.py
@@ -29,7 +29,7 @@ from .spot_rate_mixin import (
     Trade,
 )
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 GLOBAL_SENSOR_FLAG = "global_sensor_created"
@@ -40,7 +40,7 @@ async def async_setup_entry(
     entry: SpotRateConfigEntry,
     async_add_entities: Callable[[Sequence[Entity]], None],
 ):
-    logger.debug(
+    _LOGGER.debug(
         "sensor.async_setup_entry %s, data: [%s] options: [%s]",
         entry.as_dict(),
         entry.data,
@@ -281,7 +281,7 @@ class SpotRateElectricitySensor(ElectricityPriceSensor):
         attributes: dict[str, float] = {}
 
         if rate_data is None:
-            logger.debug("No rate data for %s", self.entity_id)
+            _LOGGER.debug("No rate data for %s", self.entity_id)
             self._attr_available = False
             self._value = None
             self._attr = {}
@@ -289,7 +289,7 @@ class SpotRateElectricitySensor(ElectricityPriceSensor):
 
         trade_rates = self._get_trade_rates(rate_data)
         if not trade_rates:
-            logger.debug("No trade rate data for %s", self.entity_id)
+            _LOGGER.debug("No trade rate data for %s", self.entity_id)
             self._attr_available = False
             self._value = None
             self._attr = {}
@@ -297,9 +297,9 @@ class SpotRateElectricitySensor(ElectricityPriceSensor):
 
         try:
             self._value = round(trade_rates.current_interval.price, 4)
-            logger.debug("Setting %s to %s", self.unique_id, self._value)
+            _LOGGER.debug("Setting %s to %s", self.unique_id, self._value)
         except LookupError:
-            logger.error(
+            _LOGGER.error(
                 'Current time "%s" is not found in SpotRate values:\n%s',
                 get_now(),
                 "\n\t".join(
@@ -312,7 +312,7 @@ class SpotRateElectricitySensor(ElectricityPriceSensor):
             return
 
         if not trade_rates.today:
-            logger.error("No today spot rate data found for %s", self.entity_id)
+            _LOGGER.error("No today spot rate data found for %s", self.entity_id)
             self._attr_available = False
             return
 
@@ -327,7 +327,7 @@ class SpotRateElectricitySensor(ElectricityPriceSensor):
 
         self._attr = attributes
         self._attr_available = True
-        logger.debug("Setting %s _attr_available to %s", self.unique_id, self._value)
+        _LOGGER.debug("Setting %s _attr_available to %s", self.unique_id, self._value)
 
 
 class HourFindSensor(ElectricityPriceSensor):
@@ -344,19 +344,19 @@ class HourFindSensor(ElectricityPriceSensor):
             self._attr_available = False
             self._value = None
             self._attr = {}
-            logger.debug("No value found for %s", self.unique_id)
+            _LOGGER.debug("No value found for %s", self.unique_id)
             return
 
         self._attr_available = True
         if self._value is None:
-            logger.debug(
+            _LOGGER.debug(
                 "%s initialized with %.2f at %s",
                 self.unique_id,
                 interval.price,
                 interval.dt_utc.isoformat(),
             )
         elif round(interval.price or 0, 2) != round(self._value, 2):
-            logger.debug(
+            _LOGGER.debug(
                 "%s updated from %.2f to %.2f at %s",
                 self.unique_id,
                 self._value,
@@ -364,7 +364,7 @@ class HourFindSensor(ElectricityPriceSensor):
                 interval.dt_utc.isoformat(),
             )
         else:
-            logger.debug(
+            _LOGGER.debug(
                 "%s unchanged with %.2f at %s",
                 self.unique_id,
                 interval.price,
@@ -471,7 +471,7 @@ class CurrentElectricityIntervalOrder(EnergyIntervalOrder):
             return
 
         if not trade_rates.today:
-            logger.error("No today spot rate data found for %s", self.entity_id)
+            _LOGGER.error("No today spot rate data found for %s", self.entity_id)
 
             self._attr_available = False
             self._value = None
@@ -481,12 +481,12 @@ class CurrentElectricityIntervalOrder(EnergyIntervalOrder):
         now = trade_rates.current_interval.dt_utc
         cheapest_order = interval_order[now]
         if cheapest_order != self._value:
-            logger.debug(
+            _LOGGER.debug(
                 "%s updated from %s to %s", self.unique_id, self._value, cheapest_order
             )
             self._value = cheapest_order
         else:
-            logger.debug("%s unchanged with %d", self.unique_id, cheapest_order)
+            _LOGGER.debug("%s unchanged with %d", self.unique_id, cheapest_order)
 
         for interval in trade_rates.today.interval_by_dt.values():
             self._attr[interval.dt_local.isoformat()] = [

--- a/custom_components/cz_energy_spot_prices/spot_rate.py
+++ b/custom_components/cz_energy_spot_prices/spot_rate.py
@@ -13,7 +13,7 @@ import aiohttp
 
 from .const import Commodity, SpotRateIntervalType
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 QUERY_ELECTRICITY = """<?xml version="1.0" encoding="UTF-8" ?>
@@ -121,7 +121,7 @@ class SpotRate:
         try:
             return ET.fromstring(text)
         except Exception as e:
-            logger.error("Failed to parse OTE response: %s", text)
+            _LOGGER.error("Failed to parse OTE response: %s", text)
             if "Application is not available" in text:
                 raise UpdateFailed("OTE Portal is currently not available!") from e
             raise UpdateFailed("Failed to parse query response.") from e
@@ -197,7 +197,7 @@ class SpotRate:
                     "{http://www.ote-cr.cz/schema/service/public}PeriodIndex"
                 )
                 if period_index_el is None or not period_index_el.text:
-                    logger.warning(
+                    _LOGGER.warning(
                         'Item has no "PeriodIndex" child or is empty: %s', current_date
                     )
                     current_hour = 0
@@ -227,7 +227,7 @@ class SpotRate:
 
             price_el = item.find("{http://www.ote-cr.cz/schema/service/public}Price")
             if price_el is None or price_el.text is None:
-                logger.info(
+                _LOGGER.info(
                     'Item has no "Price" child or is empty: %s %s',
                     current_date,
                     current_hour,
@@ -241,7 +241,7 @@ class SpotRate:
                     "{http://www.ote-cr.cz/schema/service/public}HourlyPrice"
                 )
                 if hourly_price_el is None or hourly_price_el.text is None:
-                    logger.info(
+                    _LOGGER.info(
                         'Item has no "HourlyPrice" child or is empty: %s %s',
                         current_date,
                         current_hour,

--- a/custom_components/cz_energy_spot_prices/spot_rate_mixin.py
+++ b/custom_components/cz_energy_spot_prices/spot_rate_mixin.py
@@ -14,7 +14,7 @@ from .coordinator import (
     IntervalTradeRateData,
 )
 
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 class Trade(StrEnum):


### PR DESCRIPTION
Home Assistant convention names the module-level logger `_LOGGER` (uppercase, leading underscore). The integration used `logger` everywhere; this commit renames it across all modules. No functional change.