### PR TITLE
Fix flaky test: jitter boundary off-by-one

### DIFF
--- a/tests/test_update_schedule.py
+++ b/tests/test_update_schedule.py
@@ -46,7 +46,7 @@ async def test_update_schedule(hass: HomeAssistant, mock_ote_electricity: AsyncM
                 )
                 assert (
                     scheduled_time - tomorrow_update_time
-                ).total_seconds() < SpotRateCoordinator.JITTER_SECONDS
+                ).total_seconds() <= SpotRateCoordinator.JITTER_SECONDS
                 call_later_mock.assert_not_called()
             else:
                 # We don't have tomorrow data...
@@ -58,7 +58,7 @@ async def test_update_schedule(hass: HomeAssistant, mock_ote_electricity: AsyncM
                     )
                     assert (
                         scheduled_time - today_update_time
-                    ).total_seconds() < SpotRateCoordinator.JITTER_SECONDS
+                    ).total_seconds() <= SpotRateCoordinator.JITTER_SECONDS
                     call_later_mock.assert_not_called()
                 else:
                     # ... next update will be soon (in 2 minutes)


### PR DESCRIPTION
`_schedule_next_update` adds `randint(1, JITTER_SECONDS)` seconds of jitter, which is INCLUSIVE of `JITTER_SECONDS`. The test asserted `... < JITTER_SECONDS` so it failed roughly 1 in 120 runs when `randint` happened to return exactly the boundary value (observed in CI as `AssertionError: assert 120.0 < 120`). Use `<=` to match the actual range produced by the production code.