### PR TITLE
chore: drop obsolete requirements-test.txt and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # GitHub Actions used by CI workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+
+  # Python dev/test dependencies tracked by uv.lock and pyproject.toml.
+  # The integration itself ships only `defusedxml` (see manifest.json);
+  # everything else here is dev-only (Home Assistant Core, pytest, ...).
+  # Group all dev updates into a single weekly PR to reduce noise and
+  # ignore security alerts for transitive dev-only packages.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,0 @@
-pytest==7.2.0
-pytest-asyncio==0.20.2


### PR DESCRIPTION
- requirements-test.txt was unused; CI uses 'uv sync --dev'

- add .github/dependabot.yml grouping dev dependency updates and tracking GitHub Actions