### PR TITLE
feat: add Most Expensive X Hours Block binary sensors

### DIFF
--- a/custom_components/cz_energy_spot_prices/__init__.py
+++ b/custom_components/cz_energy_spot_prices/__init__.py
@@ -16,6 +16,7 @@ from .config_flow import CONF_COMMODITY, CONF_INTERVAL, ELECTRICITY
 from .const import (
     CONF_ALLOW_CROSS_MIDNIGHT,
     CONF_CHEAPEST_BLOCKS,
+    CONF_MOST_EXPENSIVE_BLOCKS,
     ENTRY_COORDINATOR,
     SPOT_ELECTRICTY_COORDINATOR,
     SPOT_GAS_COORDINATOR,
@@ -65,6 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEnt
     sell_template = None
     cheapest_blocks = None
     cheapest_blocks_cross_midnight = False
+    most_expensive_blocks: list[int] | None = None
 
     # Reuse the same coordinator for all entries
     if commodity == Commodity.Electricity:
@@ -136,6 +138,22 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEnt
             config_entry.options.get(CONF_ALLOW_CROSS_MIDNIGHT) or False
         )
 
+        most_expensive_blocks_conf: str | None = config_entry.options.get(
+            CONF_MOST_EXPENSIVE_BLOCKS
+        )
+        if most_expensive_blocks_conf:
+            try:
+                most_expensive_blocks = sorted(
+                    [int(block) for block in most_expensive_blocks_conf.split(",")]
+                )
+            except ValueError:
+                _LOGGER.error(
+                    "Invalid config for most_expensive_blocks: %s",
+                    most_expensive_blocks_conf,
+                )
+        else:
+            most_expensive_blocks = []
+
     elif commodity == Commodity.Gas:
         spot_coordinator = domain_data.get(SPOT_GAS_COORDINATOR)
         if not spot_coordinator:
@@ -198,6 +216,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEnt
         sell_template=sell_template,
         cheapest_blocks=cheapest_blocks,
         cheapest_blocks_cross_midnight=cheapest_blocks_cross_midnight,
+        most_expensive_blocks=most_expensive_blocks,
         timezone=hass.config.time_zone,
         zoneinfo=ZoneInfo(hass.config.time_zone),
     )

--- a/custom_components/cz_energy_spot_prices/binary_sensor.py
+++ b/custom_components/cz_energy_spot_prices/binary_sensor.py
@@ -110,6 +110,43 @@ async def async_setup_entry(
                     )
                 )
 
+        most_expensive_blocks = coordinator.config.all_most_expensive_blocks()
+
+        for i in most_expensive_blocks:
+            sensors.append(
+                ConsecutiveMostExpensiveElectricitySensor(
+                    hours=i,
+                    hass=hass,
+                    coordinator=coordinator,
+                    device_id=entry.entry_id,
+                    trade=Trade.SPOT,
+                )
+            )
+
+        if coordinator.buy_template:
+            for i in most_expensive_blocks:
+                sensors.append(
+                    ConsecutiveMostExpensiveElectricitySensor(
+                        hours=i,
+                        hass=hass,
+                        coordinator=coordinator,
+                        device_id=entry.entry_id,
+                        trade=Trade.BUY,
+                    )
+                )
+
+        if coordinator.sell_template:
+            for i in most_expensive_blocks:
+                sensors.append(
+                    ConsecutiveMostExpensiveElectricitySensor(
+                        hours=i,
+                        hass=hass,
+                        coordinator=coordinator,
+                        device_id=entry.entry_id,
+                        trade=Trade.SELL,
+                    )
+                )
+
     async_add_entities(sensors)
 
 
@@ -189,6 +226,90 @@ class ConsecutiveCheapestElectricitySensor(BinarySpotRateSensorBase):
                 _LOGGER.error("Unable to find cheapest interval")
             else:
                 _LOGGER.error("Unable to find cheapest %s hour block", self.hours)
+            self._attr_available = False
+            return
+
+        self._attr_is_on = window.start <= now < window.end
+        start = window.start.astimezone(self.coordinator.config.zoneinfo)
+        end = window.end.astimezone(self.coordinator.config.zoneinfo)
+        self._attr = {
+            "Start": start,
+            "End": end,
+            "Min": float(round(min(window.prices), 4)),
+            "Max": float(round(max(window.prices), 4)),
+            "Mean": float(round(sum(window.prices) / len(window.prices), 4)),
+        }
+        if self.coordinator.config.interval == SpotRateIntervalType.Hour:
+            # Doesn't make sense to have these on 15min intervals
+            self._attr["Start hour"] = start.hour
+            self._attr["End hour"] = end.hour
+        self._attr_available = True
+
+
+class ConsecutiveMostExpensiveElectricitySensor(BinarySpotRateSensorBase):
+    _attr_icon: str | None = "mdi:cash-clock"
+
+    def __init__(
+        self,
+        hours: int,
+        hass: HomeAssistant,
+        coordinator: EntryCoordinator,
+        device_id: str,
+        trade: Trade,
+    ) -> None:
+        self.hours = hours
+
+        interval = (
+            "_15min"
+            if coordinator.config.interval == SpotRateIntervalType.QuarterHour
+            else ""
+        )
+
+        self._attr_unique_id = (
+            f"{device_id}_{trade.lower()}_electricity_is_most_expensive_"
+            f"{self.hours}_hours_block{interval}"
+        )
+        self._attr_translation_key = (
+            f"{trade.lower()}_electricity_is_most_expensive_hours_block{interval}"
+        )
+        self._attr_translation_placeholders = {
+            "hours": str(self.hours),
+        }
+        self.entity_id = (
+            f"binary_sensor.{trade.lower()}_electricity_is_most_expensive_"
+            f"{self.hours}_hours_block{interval}"
+        )
+
+        super().__init__(
+            hass=hass,
+            coordinator=coordinator,
+            device_id=device_id,
+            trade=trade,
+        )
+
+    @override
+    def update(self, rate_data: IntervalTradeRateData | None):
+        self._attr = {}
+
+        now = get_now()
+
+        if not rate_data:
+            self._attr_available = False
+            self._attr_is_on = None
+            return
+
+        trade_rates = self._get_trade_rates(rate_data)
+        if not trade_rates:
+            self._attr_available = False
+            self._attr_is_on = None
+            return
+
+        try:
+            window = trade_rates.most_expensive_windows[self.hours]
+        except KeyError:
+            _LOGGER.error(
+                "Unable to find most expensive %s hour block", self.hours
+            )
             self._attr_available = False
             return
 

--- a/custom_components/cz_energy_spot_prices/config_flow.py
+++ b/custom_components/cz_energy_spot_prices/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.exceptions import TemplateError
 from .const import (
     CONF_ALLOW_CROSS_MIDNIGHT,
     CONF_CHEAPEST_BLOCKS,
+    CONF_MOST_EXPENSIVE_BLOCKS,
     DOMAIN,
     CONF_ADDITIONAL_COSTS_BUY_ELECTRICITY,
     CONF_ADDITIONAL_COSTS_SELL_ELECTRICITY,
@@ -233,6 +234,19 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
                 except ValueError:
                     errors[CONF_CHEAPEST_BLOCKS] = "invalid_format"
 
+            conf_most_expensive_blocks = user_input.get(CONF_MOST_EXPENSIVE_BLOCKS)
+            most_expensive_blocks = cast(str, conf_most_expensive_blocks or "")
+            most_expensive_parts: list[int] = []
+            for part in most_expensive_blocks.split(","):
+                # Empty string is allowed and means "no most expensive sensors"
+                stripped = part.strip()
+                if not stripped:
+                    continue
+                try:
+                    most_expensive_parts.append(int(stripped))
+                except ValueError:
+                    errors[CONF_MOST_EXPENSIVE_BLOCKS] = "invalid_format"
+
             if not errors:
                 return self.async_create_entry(title="", data=user_input)
         else:
@@ -272,6 +286,18 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
                                 "Comma-separated list of hour blocks. "
                                 "For each number, a binary sensor will indicate when the "
                                 "current time falls inside the cheapest consecutive hours for that block."
+                            ),
+                        },
+                    ): cv.string,
+                    vol.Optional(
+                        CONF_MOST_EXPENSIVE_BLOCKS,
+                        default=user_input.get(CONF_MOST_EXPENSIVE_BLOCKS, ""),
+                        description={
+                            "name": "Most expensive consecutive hour blocks",
+                            "description": (
+                                "Comma-separated list of hour blocks. "
+                                "For each number, a binary sensor will indicate when the "
+                                "current time falls inside the most expensive consecutive hours for that block."
                             ),
                         },
                     ): cv.string,

--- a/custom_components/cz_energy_spot_prices/const.py
+++ b/custom_components/cz_energy_spot_prices/const.py
@@ -18,6 +18,7 @@ CONF_ADDITIONAL_COSTS_BUY_ELECTRICITY = "additional_costs_buy_electricity"
 CONF_ADDITIONAL_COSTS_SELL_ELECTRICITY = "additional_costs_sell_electricity"
 CONF_ADDITIONAL_COSTS_BUY_GAS = "additional_costs_buy_gas"
 CONF_CHEAPEST_BLOCKS = "cheapest_blocks"
+CONF_MOST_EXPENSIVE_BLOCKS = "most_expensive_blocks"
 CONF_ALLOW_CROSS_MIDNIGHT = "allow_cross_midnight"
 
 # Tracks the entry_id of the entry that owns the per-commodity global

--- a/custom_components/cz_energy_spot_prices/coordinator.py
+++ b/custom_components/cz_energy_spot_prices/coordinator.py
@@ -55,6 +55,7 @@ class EntryConfig:
     sell_template: Template | None
     cheapest_blocks: Sequence[int] | None
     cheapest_blocks_cross_midnight: bool
+    most_expensive_blocks: Sequence[int] | None
 
     def all_cheapest_blocks(self) -> list[int | None]:
         """Return all cheapest blocks, including blocks that take just one interval (it's value is None)."""
@@ -81,6 +82,37 @@ class EntryConfig:
 
             cheapest_blocks.append(block)
         return cheapest_blocks
+
+    def all_most_expensive_blocks(self) -> list[int]:
+        """Return all most expensive blocks configured by the user.
+
+        Unlike :meth:`all_cheapest_blocks` this does not auto-include the
+        single-interval case, because the most-expensive sensors are an
+        opt-in feature that should not create unexpected entities for
+        existing users.
+        """
+        most_expensive_blocks: list[int] = []
+        for block in self.most_expensive_blocks or []:
+            try:
+                block = int(block)
+            except ValueError:
+                _LOGGER.error(
+                    "Invalid interval for most expensive blocks: %s", block
+                )
+                continue
+
+            if block < 1 or block > 23:
+                _LOGGER.error(
+                    "Invalid interval for most expensive blocks: %s", block
+                )
+                continue
+
+            if block in most_expensive_blocks:
+                # Prevent duplication
+                continue
+
+            most_expensive_blocks.append(block)
+        return most_expensive_blocks
 
 
 @final
@@ -170,6 +202,7 @@ class IntervalSpotRateData:
         self._today_tomorrow_by_dt: dict[datetime, SpotRateInterval] = {}
 
         self.cheapest_windows: dict[int | None, Window] = {}
+        self.most_expensive_windows: dict[int, Window] = {}
 
         # Create individual SpotRateInterval instances and compute statistics while doing that
         for utc_hour, rate in rates.items():
@@ -222,6 +255,22 @@ class IntervalSpotRateData:
                     _LOGGER.error("Unable to find cheapest interval")
                 else:
                     _LOGGER.error("Unable to find cheapest %s hour block", block)
+
+        for block in config.all_most_expensive_blocks():
+            if config.cheapest_blocks_cross_midnight:
+                intervals_for_most_expensive = self._today_tomorrow_by_dt
+            else:
+                intervals_for_most_expensive = self._today_day.interval_by_dt
+
+            try:
+                window = find_most_expensive_window(
+                    intervals_for_most_expensive,
+                    hours=block,
+                    interval=config.interval,
+                )
+                self.most_expensive_windows[block] = window
+            except ValueError:
+                _LOGGER.error("Unable to find most expensive %s hour block", block)
 
     def interval_for_dt(self, dt: datetime) -> SpotRateInterval:
         if self.config.interval == SpotRateIntervalType.Day:
@@ -393,6 +442,33 @@ def find_cheapest_window(
     hours: int | None,
     interval: SpotRateIntervalType,
 ) -> Window:
+    return _find_extremum_window(
+        interval_by_dt,
+        hours=hours,
+        interval=interval,
+        most_expensive=False,
+    )
+
+
+def find_most_expensive_window(
+    interval_by_dt: dict[datetime, SpotRateInterval],
+    hours: int | None,
+    interval: SpotRateIntervalType,
+) -> Window:
+    return _find_extremum_window(
+        interval_by_dt,
+        hours=hours,
+        interval=interval,
+        most_expensive=True,
+    )
+
+
+def _find_extremum_window(
+    interval_by_dt: dict[datetime, SpotRateInterval],
+    hours: int | None,
+    interval: SpotRateIntervalType,
+    most_expensive: bool,
+) -> Window:
     # window size is how many interval will fit into given X hours block
     window_size = 1
     if hours is not None:
@@ -403,10 +479,10 @@ def find_cheapest_window(
 
     all_prices = [i.price for i in interval_by_dt.values()]
 
-    min_sum = None
-    min_sum_start = None
-    min_sum_end = None
-    min_sum_prices = None
+    best_sum = None
+    best_sum_start = None
+    best_sum_end = None
+    best_sum_prices = None
 
     for i, (dt, _) in enumerate(interval_by_dt.items()):
         window = all_prices[i : (i + window_size)]
@@ -414,22 +490,26 @@ def find_cheapest_window(
             continue
 
         window_sum = sum(window)
-        if min_sum is None or window_sum < min_sum:
-            min_sum = window_sum
-            min_sum_start = dt
+        is_better = (
+            best_sum is None
+            or (window_sum > best_sum if most_expensive else window_sum < best_sum)
+        )
+        if is_better:
+            best_sum = window_sum
+            best_sum_start = dt
             if interval == SpotRateIntervalType.Hour:
-                min_sum_end = dt + timedelta(hours=window_size)
+                best_sum_end = dt + timedelta(hours=window_size)
             else:
-                min_sum_end = dt + timedelta(minutes=window_size * 15)
-            min_sum_prices = window
+                best_sum_end = dt + timedelta(minutes=window_size * 15)
+            best_sum_prices = window
 
-    if min_sum_start is None or min_sum_end is None or min_sum_prices is None:
+    if best_sum_start is None or best_sum_end is None or best_sum_prices is None:
         raise ValueError()
 
     return Window(
-        start=min_sum_start,
-        end=min_sum_end,
-        prices=min_sum_prices,
+        start=best_sum_start,
+        end=best_sum_end,
+        prices=best_sum_prices,
     )
 
 

--- a/custom_components/cz_energy_spot_prices/translations/cs.json
+++ b/custom_components/cz_energy_spot_prices/translations/cs.json
@@ -44,6 +44,7 @@
                     "additional_costs_sell_electricity": "Cena elektřiny při prodeji",
                     "additional_costs_buy_gas": "Cena plynu při nákupu",
                     "cheapest_blocks": "Nejlevnější bloky po sobě jdoucích hodin",
+                    "most_expensive_blocks": "Nejdražší bloky po sobě jdoucích hodin",
                     "allow_cross_midnight": "Povolit přechod nejlevnějších bloků přes půlnoc"
                 },
                 "data_description": {
@@ -51,6 +52,7 @@
                     "additional_costs_sell_electricity": "Šablona pro výpočet konečné ceny po zahrnutí dodatečných nákladů. Použijte `value` pro získání aktualní ceny, například pro odečtení fixního poplatku operátora ve výši 0.25 použijte `'{{ value - 0.25 }}`.  Použijte `hour` pro výpočet ceny v dané hodině, pokud se sazba v jednotlivých hodinách liší, například pro vysoký a nízký tarif. Hodnota `hour` je v UTC. Pokud potřebujete lokální čas použijte `as_local(hour)`. Pokud nezadáte žádnou šablonu, senzor nebude vytvořen.",
                     "additional_costs_buy_gas": "Šablona pro výpočet konečné ceny po zahrnutí dodatečných nákladů. Použijte `value` pro získání aktualní ceny. Můžete použít `day` v UTC pro spotové ceny. Pokud nezadáte žádnou šablonu, senzor nebude vytvořen.",
                     "cheapest_blocks": "Seznam délek bloků v hodinách oddělený čárkami. Pro každou délku se vytvoří binární senzor, který bude zapnutý během nejlevnějších po sobě jdoucích hodin dne.",
+                    "most_expensive_blocks": "Seznam délek bloků v hodinách oddělený čárkami. Pro každou délku se vytvoří binární senzor, který bude zapnutý během nejdražších po sobě jdoucích hodin dne. Nechání prázdné znamená, že se senzory nevytvoří.",
                     "allow_cross_midnight": "Pokud je povoleno, bloky mohou přeskočit půlnoc (např. 23:00–01:00). Protože se ceny zveřejňují po dnech, tyto bloky se mohou po načtení nových dat změnit."
                 }
             }
@@ -76,6 +78,12 @@
             "spot_electricity_is_cheapest_hours_block_15min": {
                 "name": "Aktuální blok {hours} hodin 15minutových spotových cen elektřiny je nejlevnější"
             },
+            "spot_electricity_is_most_expensive_hours_block": {
+                "name": "Aktuální blok {hours} hodin spotových cen elektřiny je nejdražší"
+            },
+            "spot_electricity_is_most_expensive_hours_block_15min": {
+                "name": "Aktuální blok {hours} hodin 15minutových spotových cen elektřiny je nejdražší"
+            },
             "spot_gas_has_tomorrow_data": {
                 "name": "K dispozici zítřejší spotové ceny plynu"
             },
@@ -91,6 +99,12 @@
             "buy_electricity_is_cheapest_hours_block_15min": {
                 "name": "Aktuální blok {hours} hodin 15minutových nákupních cen elektřiny je nejlevnější"
             },
+            "buy_electricity_is_most_expensive_hours_block": {
+                "name": "Aktuální blok {hours} hodin nákupních cen elektřiny je nejdražší"
+            },
+            "buy_electricity_is_most_expensive_hours_block_15min": {
+                "name": "Aktuální blok {hours} hodin 15minutových nákupních cen elektřiny je nejdražší"
+            },
             "sell_electricity_is_cheapest": {
                 "name": "Aktuální prodejní cena elektřiny je nejlevnější"
             },
@@ -102,6 +116,12 @@
             },
             "sell_electricity_is_cheapest_hours_block_15min": {
                 "name": "Aktuální blok {hours} hodin 15minutových prodejních cen elektřiny je nejlevnější"
+            },
+            "sell_electricity_is_most_expensive_hours_block": {
+                "name": "Aktuální blok {hours} hodin prodejních cen elektřiny je nejdražší"
+            },
+            "sell_electricity_is_most_expensive_hours_block_15min": {
+                "name": "Aktuální blok {hours} hodin 15minutových prodejních cen elektřiny je nejdražší"
             }
         },
         "sensor": {

--- a/custom_components/cz_energy_spot_prices/translations/en.json
+++ b/custom_components/cz_energy_spot_prices/translations/en.json
@@ -44,6 +44,7 @@
                     "additional_costs_sell_electricity": "Electricity cost when selling",
                     "additional_costs_buy_gas": "Gas cost when buying",
                     "cheapest_blocks": "Cheapest consecutive hour blocks",
+                    "most_expensive_blocks": "Most expensive consecutive hour blocks",
                     "allow_cross_midnight": "Allow cheapest blocks to cross midnight"
                 },
                 "data_description": {
@@ -51,6 +52,7 @@
                     "additional_costs_sell_electricity": "Template to calculate actual costs with additional fees. Use `value` to get current price, for example, to subtract fixed 0.25 operator fee use `'{{ value - 0.25 }}`. Use `hour` to calculate the price for a specific hour if the rate varies by hour, such as high and low tariffs. The `hour` value is in UTC. If you need the local time, use `as_local(hour)`. If you do not enter a template, the sensor will not be created.",
                     "additional_costs_buy_gas": "Template to calculate actual costs with additional fees. Use `value` to get current spot price. You can use `day` in UTC for spot prices. If you do not enter a template, the sensor will not be created.",
                     "cheapest_blocks": "Comma-separated list of hour block lengths. For each number, a binary sensor is created that turns ON during the cheapest consecutive hours in a day.",
+                    "most_expensive_blocks": "Comma-separated list of hour block lengths. For each number, a binary sensor is created that turns ON during the most expensive consecutive hours in a day. Leave empty to disable.",
                     "allow_cross_midnight": "If enabled, blocks can span midnight (e.g., 23:00-01:00). Since spot prices reset daily, these blocks may shift when next day data arrives."
                 }
             }
@@ -76,6 +78,12 @@
             "spot_electricity_is_cheapest_hours_block_15min": {
                 "name": "Current 15min Spot Electricity is Cheapest {hours} Hours Block"
             },
+            "spot_electricity_is_most_expensive_hours_block": {
+                "name": "Current Spot Electricity is Most Expensive {hours} Hours Block"
+            },
+            "spot_electricity_is_most_expensive_hours_block_15min": {
+                "name": "Current 15min Spot Electricity is Most Expensive {hours} Hours Block"
+            },
             "spot_gas_has_tomorrow_data": {
                 "name": "Spot Gas has Tomorrow Data"
             },
@@ -91,6 +99,12 @@
             "buy_electricity_is_cheapest_hours_block_15min": {
                 "name": "Current 15min Buy Electricity is Cheapest {hours} Hours Block"
             },
+            "buy_electricity_is_most_expensive_hours_block": {
+                "name": "Current Buy Electricity is Most Expensive {hours} Hours Block"
+            },
+            "buy_electricity_is_most_expensive_hours_block_15min": {
+                "name": "Current 15min Buy Electricity is Most Expensive {hours} Hours Block"
+            },
             "sell_electricity_is_cheapest": {
                 "name": "Current Sell Electricity is Cheapest"
             },
@@ -102,6 +116,12 @@
             },
             "sell_electricity_is_cheapest_hours_block_15min": {
                 "name": "Current 15min Sell Electricity is Cheapest {hours} Hours Block"
+            },
+            "sell_electricity_is_most_expensive_hours_block": {
+                "name": "Current Sell Electricity is Most Expensive {hours} Hours Block"
+            },
+            "sell_electricity_is_most_expensive_hours_block_15min": {
+                "name": "Current 15min Sell Electricity is Most Expensive {hours} Hours Block"
             }
         },
         "sensor": {

--- a/custom_components/cz_energy_spot_prices/translations/sk.json
+++ b/custom_components/cz_energy_spot_prices/translations/sk.json
@@ -44,6 +44,7 @@
                     "additional_costs_sell_electricity": "Cena elektriny pri predaji",
                     "additional_costs_buy_gas": "Cena plynu pri nákupe",
                     "cheapest_blocks": "Najlacnejšie bloky po sebe nasledujúcich hodín",
+                    "most_expensive_blocks": "Najdrahšie bloky po sebe nasledujúcich hodín",
                     "allow_cross_midnight": "Povoliť prechod najlacnejších blokov cez polnoc"
                 },
                 "data_description": {
@@ -51,6 +52,7 @@
                     "additional_costs_sell_electricity": "Šablóna pre výpočet konečnej ceny po zahrnutí dodatočných nákladov. Použite `value` na získanie aktuálnej ceny, napríklad na odpočítanie fixného poplatku operátora vo výške 0.25 použite `'{{ value - 0.25 }}`. Použite `hour` na výpočet ceny v danej hodine, ak sa sadzba v jednotlivých hodinách líši, napríklad pre vysoký a nízky tarif. Hodnota `hour` je v UTC. Ak potrebujete lokálny čas, použite `as_local(hour)`. Ak nezadáte žiadnu šablónu, senzor nebude vytvorený.",
                     "additional_costs_buy_gas": "Šablóna pre výpočet konečnej ceny po zahrnutí dodatočných nákladov. Použite `value` na získanie aktuálnej ceny. Môžete použiť `day` v UTC pre spotové ceny. Ak nezadáte žiadnu šablónu, senzor nebude vytvorený.",
                     "cheapest_blocks": "Zoznam dĺžok blokov v hodinách oddelený čiarkami. Pre každú dĺžku sa vytvorí binárny senzor, ktorý bude zapnutý počas najlacnejších po sebe nasledujúcich hodín dňa.",
+                    "most_expensive_blocks": "Zoznam dĺžok blokov v hodinách oddelený čiarkami. Pre každú dĺžku sa vytvorí binárny senzor, ktorý bude zapnutý počas najdrahších po sebe nasledujúcich hodín dňa. Ponechanie prázdne znamená, že sa senzory nevytvoria.",
                     "allow_cross_midnight": "Ak je povolené, bloky môžu presiahnuť polnoc (napr. 23:00-01:00). Keďže ceny sa poskytujú po dňoch, tieto bloky sa môžu po načítaní nových údajov zmeniť."
                 }
             }
@@ -76,6 +78,12 @@
             "spot_electricity_is_cheapest_hours_block_15min": {
                 "name": "Aktuálny blok {hours} hodín 15-minútových spotových cien elektriny je najlacnejší"
             },
+            "spot_electricity_is_most_expensive_hours_block": {
+                "name": "Aktuálny blok {hours} hodín spotových cien elektriny je najdrahší"
+            },
+            "spot_electricity_is_most_expensive_hours_block_15min": {
+                "name": "Aktuálny blok {hours} hodín 15-minútových spotových cien elektriny je najdrahší"
+            },
             "spot_gas_has_tomorrow_data": {
                 "name": "K dispozícii zajtrajšie spotové ceny plynu"
             },
@@ -91,6 +99,12 @@
             "buy_electricity_is_cheapest_hours_block_15min": {
                 "name": "Aktuálny blok {hours} hodín 15-minútových nákupných cien elektriny je najlacnejší"
             },
+            "buy_electricity_is_most_expensive_hours_block": {
+                "name": "Aktuálny blok {hours} hodín nákupných cien elektriny je najdrahší"
+            },
+            "buy_electricity_is_most_expensive_hours_block_15min": {
+                "name": "Aktuálny blok {hours} hodín 15-minútových nákupných cien elektriny je najdrahší"
+            },
             "sell_electricity_is_cheapest": {
                 "name": "Aktuálna predajná cena elektriny je najlacnejšia"
             },
@@ -102,6 +116,12 @@
             },
             "sell_electricity_is_cheapest_hours_block_15min": {
                 "name": "Aktuálny blok {hours} hodín 15-minútových predajných cien elektriny je najlacnejší"
+            },
+            "sell_electricity_is_most_expensive_hours_block": {
+                "name": "Aktuálny blok {hours} hodín predajných cien elektriny je najdrahší"
+            },
+            "sell_electricity_is_most_expensive_hours_block_15min": {
+                "name": "Aktuálny blok {hours} hodín 15-minútových predajných cien elektriny je najdrahší"
             }
         },
         "sensor": {

--- a/tests/test_find_cheapest_window.py
+++ b/tests/test_find_cheapest_window.py
@@ -6,7 +6,12 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 import pytest
 from custom_components.cz_energy_spot_prices.const import SpotRateIntervalType
-from custom_components.cz_energy_spot_prices.coordinator import PRAGUE_TZ, SpotRateInterval, find_cheapest_window
+from custom_components.cz_energy_spot_prices.coordinator import (
+    PRAGUE_TZ,
+    SpotRateInterval,
+    find_cheapest_window,
+    find_most_expensive_window,
+)
 
 
 BASE_DT = datetime(2025, 1, 1, 0, tzinfo=PRAGUE_TZ)
@@ -166,6 +171,130 @@ def test_find_cheapest_window_15min(
     offset: int,
 ):
     window = find_cheapest_window(
+        interval_by_dt=interval_15mins,
+        hours=hours,
+        interval=SpotRateIntervalType.QuarterHour,
+    )
+    assert window.prices == prices
+    assert window.start == BASE_DT + timedelta(minutes=offset * 15)
+    assert window.end == BASE_DT + timedelta(minutes=(offset + len(prices)) * 15)
+
+
+def test_find_most_expensive_window_no_data():
+    with pytest.raises(ValueError):
+        _ = find_most_expensive_window(
+            {}, hours=None, interval=SpotRateIntervalType.Hour
+        )
+
+    with pytest.raises(ValueError):
+        _ = find_most_expensive_window({}, hours=2, interval=SpotRateIntervalType.Hour)
+
+    with pytest.raises(ValueError):
+        _ = find_most_expensive_window(
+            {}, hours=None, interval=SpotRateIntervalType.QuarterHour
+        )
+
+    with pytest.raises(ValueError):
+        _ = find_most_expensive_window(
+            {}, hours=2, interval=SpotRateIntervalType.QuarterHour
+        )
+
+
+def test_find_most_expensive_window_not_enough_data(
+    interval_one_value: dict[datetime, SpotRateInterval],
+):
+    with pytest.raises(ValueError):
+        _ = find_most_expensive_window(
+            interval_by_dt=interval_one_value,
+            hours=2,
+            interval=SpotRateIntervalType.Hour,
+        )
+
+    with pytest.raises(ValueError):
+        _ = find_most_expensive_window(
+            interval_by_dt=interval_one_value,
+            hours=1,
+            interval=SpotRateIntervalType.QuarterHour,
+        )
+
+
+@pytest.mark.parametrize(
+    "hours,interval",
+    [
+        (None, SpotRateIntervalType.Hour),
+        (1, SpotRateIntervalType.Hour),
+        (None, SpotRateIntervalType.QuarterHour),
+    ],
+)
+def test_find_most_expensive_window_one_interval(
+    interval_one_value: dict[datetime, SpotRateInterval],
+    hours: int | None,
+    interval: SpotRateIntervalType,
+):
+    first_interval = list(interval_one_value.values())[0]
+
+    window = find_most_expensive_window(
+        interval_by_dt=interval_one_value, hours=hours, interval=interval
+    )
+    assert window.prices == [Decimal(10)]
+    assert window.start == first_interval.dt_utc
+    if interval == SpotRateIntervalType.Hour:
+        assert window.end == first_interval.dt_utc + timedelta(hours=1)
+    else:
+        assert window.end == first_interval.dt_utc + timedelta(minutes=15)
+
+
+@pytest.mark.parametrize(
+    "hours,prices,offset",
+    (
+        # 19 at index 17 is the most expensive single hour
+        (None, [19], 17),
+        (1, [19], 17),
+        # 19 + 17 at indices 17-18
+        (2, [19, 17], 17),
+        # 19 + 17 + 18 at indices 17-19
+        (3, [19, 17, 18], 17),
+        # First-wins on ties: indices 16-19 sum 68 == indices 17-20 sum 68
+        (4, [14, 19, 17, 18], 16),
+        # Indices 17-21 sum 83
+        (5, [19, 17, 18, 14, 15], 17),
+        # Indices 17-22 sum 100
+        (6, [19, 17, 18, 14, 15, 17], 17),
+    ),
+)
+def test_find_most_expensive_window_60min(
+    interval_60mins: dict[datetime, SpotRateInterval],
+    hours: int | None,
+    prices: list[Decimal],
+    offset: int,
+):
+    window = find_most_expensive_window(
+        interval_by_dt=interval_60mins,
+        hours=hours,
+        interval=SpotRateIntervalType.Hour,
+    )
+    assert window.prices == prices
+    assert window.start == BASE_DT + timedelta(hours=offset)
+    assert window.end == BASE_DT + timedelta(hours=offset + len(prices))
+
+
+@pytest.mark.parametrize(
+    "hours,prices,offset",
+    (
+        (None, [19], 17),
+        # hours=1 -> 4 consecutive 15-min slots; first-wins on tie at indices 16-19
+        (1, [14, 19, 17, 18], 16),
+        # hours=2 -> 8 consecutive 15-min slots; max sum 127 at indices 15-22
+        (2, [13, 14, 19, 17, 18, 14, 15, 17], 15),
+    ),
+)
+def test_find_most_expensive_window_15min(
+    interval_15mins: dict[datetime, SpotRateInterval],
+    hours: int | None,
+    prices: list[Decimal],
+    offset: int,
+):
+    window = find_most_expensive_window(
         interval_by_dt=interval_15mins,
         hours=hours,
         interval=SpotRateIntervalType.QuarterHour,


### PR DESCRIPTION
Closes #58

## What

Adds a new opt-in configuration option `most_expensive_blocks` (Comma-separated
list of hour block lengths) that mirrors the existing `cheapest_blocks` feature.
For each requested block length, a binary sensor is created that turns ON during
the most expensive consecutive hours of the day.

Sensors are created for `spot`, `buy`, and `sell` trades whenever the
corresponding additional-cost template is configured, just like for the cheapest
blocks. Both 60-minute and 15-minute intervals are supported.

Example entity IDs (with `most_expensive_blocks` set to e.g. `2,4`):

- `binary_sensor.spot_electricity_is_most_expensive_2_hours_block`
- `binary_sensor.spot_electricity_is_most_expensive_4_hours_block`
- `binary_sensor.buy_electricity_is_most_expensive_2_hours_block_15min`
- ... and analogous variants for `buy` / `sell` and `_15min`.

Each sensor exposes the same attributes as the cheapest counterpart:
`Start`, `End`, `Min`, `Max`, `Mean` (and `Start hour`/`End hour` for the
hourly interval).

## Why

A frequently requested feature (#58, also brought up in #80) — useful for
shifting flexible loads OFF during the most expensive window (or for
notifications, automations that pause non-essential consumers, etc.).
Until now users had to roll their own Jinja templates; this brings the feature
in-line with the existing `Cheapest X Hours Block` sensors.

## Design notes

- **Opt-in only.** Unlike `cheapest_blocks` (which auto-creates a single
  "is cheapest" sensor even with no configured blocks), `most_expensive_blocks`
  creates **no sensors** when left empty. This avoids surprising existing users
  with new entities after upgrade.
- **No new cross-midnight flag.** The existing `allow_cross_midnight` option
  (currently disabled in the UI but still honored at runtime) is reused for
  symmetry.
- **Refactor.** `find_cheapest_window` is refactored into a thin wrapper around
  a private `_find_extremum_window` helper that takes a `most_expensive: bool`
  flag; `find_most_expensive_window` is the matching public function. This
  keeps both implementations in sync (e.g. tie-breaking behavior is identical:
  earliest window wins on ties).

## Translations

Added `most_expensive_blocks` option label & description and entity name
templates for all 6 trade × interval combinations to `en`, `cs`, `sk`.

## Tests

Added `test_find_most_expensive_window_*` test cases mirroring the existing
`find_cheapest_window` tests (no-data, not-enough-data, single value,
parametrized 60-min and 15-min cases). Existing tests are unchanged and
continue to pass.
