### PR TITLE
ci: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   hacs:
     name: HACS Action

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: python


### PR DESCRIPTION
Adds explicit `permissions: contents: read` to all three workflow files (`tests.yaml`, `hassfest.yaml`, `hacs.yaml`).

## Why

None of these workflows need write access to repository contents, packages, issues, etc. Explicit minimal permissions follow [GitHub's hardening guidance](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) and silence the `actions/missing-workflow-permissions` code scanning warning (3 alerts).

## Risk

None — read-only token is sufficient for `actions/checkout`, `setup-uv`, `hassfest` and `hacs/action`. Workflow behavior is unchanged.