### PR TITLE
Persist CNB exchange rates across restarts

### DIFF
--- a/custom_components/cz_energy_spot_prices/__init__.py
+++ b/custom_components/cz_energy_spot_prices/__init__.py
@@ -189,6 +189,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SpotRateConfigEnt
                 hass, config_entry, domain_data, FX_COORDINATOR
             )
             await fx_coordinator.async_register_shutdown()
+            # Restore the last known good rates before contacting CNB so
+            # converted-price sensors can survive a restart during an outage.
+            await fx_coordinator.async_load_persisted()
             # Fetch initial data (first refresh)
             await fx_coordinator.async_refresh()
         else:

--- a/custom_components/cz_energy_spot_prices/coordinator.py
+++ b/custom_components/cz_energy_spot_prices/coordinator.py
@@ -968,6 +968,11 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
 
         self._cnb = CnbRate(session=async_get_clientsession(hass))
         self._retry_attempt = 0
+        self._store: Store[dict[str, str]] = Store(
+            hass,
+            STORAGE_VERSION,
+            f"{DOMAIN}.fx_rates",
+        )
 
         # Update on midnight local (hass) time
         self._update_schedule: Callable[[], None] | None = (
@@ -979,6 +984,40 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
                 second=0,
             )
         )
+
+    @staticmethod
+    def _serialize(data: dict[str, Decimal]) -> dict[str, str]:
+        """Serialize currency rates for persistence."""
+        return {currency: str(rate) for currency, rate in data.items()}
+
+    @staticmethod
+    def _deserialize(raw: dict[str, str]) -> dict[str, Decimal]:
+        """Deserialize previously persisted currency rates."""
+        return {currency: Decimal(rate) for currency, rate in raw.items()}
+
+    async def async_load_persisted(self) -> bool:
+        """Load the last known good CNB rates from Home Assistant storage."""
+        if self.data is not None:
+            return True
+
+        raw = await self._store.async_load()
+        if not raw:
+            return False
+
+        try:
+            loaded = self._deserialize(raw)
+        except (InvalidOperation, TypeError, AttributeError) as exc:
+            _LOGGER.warning("Failed to deserialize persisted CNB FX rates: %s", exc)
+            return False
+
+        if not loaded:
+            return False
+
+        self.async_set_updated_data(loaded)
+        _LOGGER.debug(
+            "FxCoordinator loaded persisted data with %d currencies", len(loaded)
+        )
+        return True
 
     async def async_stop(self):
         """Cancel scheduled jobs."""
@@ -1040,6 +1079,12 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
     @override
     async def _async_update_data(self):
         rates = await self._fetch_data_with_retry()
+
+        try:
+            await self._store.async_save(self._serialize(rates))
+        except Exception:  # pragma: no cover - defensive, storage is local
+            _LOGGER.exception("Failed to persist CNB FX rates")
+
         return rates
 
 

--- a/tests/test_fx_coordinator.py
+++ b/tests/test_fx_coordinator.py
@@ -1,0 +1,109 @@
+"""Tests for CNB exchange-rate coordination and persistence."""
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+from freezegun import freeze_time
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.cz_energy_spot_prices.cnb_rate import CnbRateError
+from custom_components.cz_energy_spot_prices.coordinator import FxCoordinator
+
+from . import BASE_DT, get_entry, init_integration
+
+
+async def test_loads_persisted_rates(hass: HomeAssistant) -> None:
+    """Persisted rates are restored with Decimal precision."""
+    coordinator = FxCoordinator(hass)
+    coordinator._store.async_load = AsyncMock(  # pyright: ignore[reportPrivateUsage,reportAttributeAccessIssue]
+        return_value={"CZK": "1", "EUR": "24.315"}
+    )
+
+    assert await coordinator.async_load_persisted()
+    assert coordinator.data == {
+        "CZK": Decimal("1"),
+        "EUR": Decimal("24.315"),
+    }
+    await coordinator.async_stop()
+
+
+async def test_rejects_invalid_persisted_rates(hass: HomeAssistant) -> None:
+    """A damaged cache falls through to the normal network refresh."""
+    coordinator = FxCoordinator(hass)
+    coordinator._store.async_load = AsyncMock(  # pyright: ignore[reportPrivateUsage,reportAttributeAccessIssue]
+        return_value={"CZK": "not-a-number"}
+    )
+
+    assert not await coordinator.async_load_persisted()
+    assert coordinator.data is None
+    await coordinator.async_stop()
+
+
+async def test_saves_successful_rates(hass: HomeAssistant) -> None:
+    """Every successful CNB refresh replaces the persisted rates."""
+    coordinator = FxCoordinator(hass)
+    rates = {"CZK": Decimal("1"), "EUR": Decimal("24.315")}
+    coordinator._fetch_data_with_retry = AsyncMock(  # pyright: ignore[reportPrivateUsage,reportAttributeAccessIssue]
+        return_value=rates
+    )
+    coordinator._store.async_save = AsyncMock()  # pyright: ignore[reportPrivateUsage,reportAttributeAccessIssue]
+
+    assert await coordinator._async_update_data() == rates  # pyright: ignore[reportPrivateUsage]
+    coordinator._store.async_save.assert_awaited_once_with(  # pyright: ignore[reportPrivateUsage,reportAttributeAccessIssue]
+        {"CZK": "1", "EUR": "24.315"}
+    )
+    await coordinator.async_stop()
+
+
+async def test_keeps_persisted_rates_when_cnb_is_unavailable(
+    hass: HomeAssistant,
+) -> None:
+    """A failed startup refresh does not discard restored rates."""
+    coordinator = FxCoordinator(hass)
+    coordinator._store.async_load = AsyncMock(  # pyright: ignore[reportPrivateUsage,reportAttributeAccessIssue]
+        return_value={"CZK": "1", "EUR": "24.315"}
+    )
+    coordinator._fetch_data = AsyncMock(  # pyright: ignore[reportPrivateUsage,method-assign]
+        side_effect=CnbRateError("CNB unavailable")
+    )
+
+    assert await coordinator.async_load_persisted()
+    with patch(
+        "custom_components.cz_energy_spot_prices.coordinator.event.async_call_later"
+    ):
+        await coordinator.async_refresh()
+
+    assert coordinator.data == {
+        "CZK": Decimal("1"),
+        "EUR": Decimal("24.315"),
+    }
+    assert not coordinator.last_update_success
+    await coordinator.async_stop()
+
+
+async def test_setup_uses_persisted_rates_during_cnb_outage(
+    hass: HomeAssistant,
+    mock_ote_electricity: AsyncMock,
+    mock_cnb: AsyncMock,
+) -> None:
+    """A restarted CZK entry computes its sensors from cached CNB rates."""
+    entry: MockConfigEntry = get_entry(currency="CZK")
+    await hass.config.async_set_time_zone("Europe/Prague")
+
+    with freeze_time(BASE_DT):
+        assert await init_integration(hass, [entry])
+        assert entry.runtime_data.data is not None
+        assert await hass.config_entries.async_unload(entry.entry_id)
+
+        mock_cnb.side_effect = CnbRateError("CNB unavailable")
+        with patch(
+            "custom_components.cz_energy_spot_prices.coordinator.event.async_call_later"
+        ):
+            assert await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert entry.state is ConfigEntryState.LOADED
+        assert entry.runtime_data.data is not None
+        assert await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
## Summary
- persist successful CNB exchange-rate responses in Home Assistant storage
- restore cached rates before the initial CNB refresh
- keep CZK and other converted-price sensors available when CNB is down during restart
- safely ignore missing or corrupt cached data

## Validation
- uv run pytest -q: 186 passed
- Ruff: passed
- Pyrefly: 0 errors
- Home Assistant 2026.5.2 browser test: forced CNB outage after cache creation; hourly, 15-minute, and gas CZK sensors retained numeric values, with no examined energy entity unavailable

Fixes #62