### PR TITLE
Add long-term statistics for current price sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ You can install the integration using HACS (preferred) or manually.
 
 The integration provides several sensors to monitor electricity/gas prices and related data. Below is a list of available sensors and their attributes.
 
+Current electricity and gas price sensors support Home Assistant long-term statistics and can be used in the Statistics Graph card. Statistics are collected from the time the integration version containing this support is installed; existing history is not backfilled. For electricity, the graph shows the historical state of the current-price sensor, not the future prices exposed in its attributes.
+
 ### Electricity sensors
 
 When the 15-minute interval is selected, the same sensors are also created with the `_15min` suffix in their entity id (e.g. `sensor.current_spot_electricity_price_15min`).

--- a/custom_components/cz_energy_spot_prices/sensor.py
+++ b/custom_components/cz_energy_spot_prices/sensor.py
@@ -4,7 +4,7 @@ import logging
 from typing import Callable, override
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 
@@ -250,6 +250,7 @@ class ElectricityPriceSensor(ElectricitySpotRateSensorBase):
 
 class SpotRateElectricitySensor(ElectricityPriceSensor):
     _name_template = "current_{trade}_electricity_price{interval}"
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self,
@@ -549,6 +550,8 @@ class GasPriceSensor(SpotRateSensorBase):
 
 
 class TodayGasSensor(GasPriceSensor):
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
     def __init__(
         self,
         hass: HomeAssistant,

--- a/tests/test_gas_sensors.py
+++ b/tests/test_gas_sensors.py
@@ -87,11 +87,14 @@ async def test_today_tomorrow_gas_spot_sensors(
             attr["unit_of_measurement"]
             == f"{'€' if currency == 'EUR' else 'Kč'}/{unit}"
         )
+        assert attr["state_class"] == "measurement"
+        assert "device_class" not in attr
         assert attr["icon"] == "mdi:cash"
 
         tomorrow = hass.states.get("sensor.tomorrow_spot_gas_price")
         assert tomorrow is not None
         assert approx(tomorrow.state) == tomorrow_eur_per_mwh * rate
+        assert "state_class" not in tomorrow.attributes
 
 
 @pytest.mark.asyncio
@@ -129,10 +132,12 @@ async def test_gas_buy_template_applied(
         buy_today = hass.states.get("sensor.current_buy_gas_price")
         assert buy_today is not None
         assert approx(buy_today.state) == today_eur_per_mwh + offset
+        assert buy_today.attributes["state_class"] == "measurement"
 
         buy_tomorrow = hass.states.get("sensor.tomorrow_buy_gas_price")
         assert buy_tomorrow is not None
         assert approx(buy_tomorrow.state) == tomorrow_eur_per_mwh + offset
+        assert "state_class" not in buy_tomorrow.attributes
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -115,6 +115,8 @@ async def test_electricity_spot_rate_sensor(
                 sensor_60min.attributes["unit_of_measurement"]
                 == f"{'€' if currency == 'EUR' else 'Kč'}/{unit}"
             )
+            assert sensor_60min.attributes["state_class"] == "measurement"
+            assert "device_class" not in sensor_60min.attributes
             assert sensor_60min.attributes["icon"] == icon
             assert (
                 sensor_60min.attributes["friendly_name"]
@@ -144,6 +146,8 @@ async def test_electricity_spot_rate_sensor(
                 sensor_15min.attributes["unit_of_measurement"]
                 == f"{'€' if currency == 'EUR' else 'Kč'}/{unit}"
             )
+            assert sensor_15min.attributes["state_class"] == "measurement"
+            assert "device_class" not in sensor_15min.attributes
             assert sensor_15min.attributes["icon"] == icon
             assert (
                 sensor_15min.attributes["friendly_name"]
@@ -205,6 +209,7 @@ async def test_cheapest_sensor(
             attr["unit_of_measurement"]
             == f"{'€' if currency == 'EUR' else 'Kč'}/{unit}"
         )
+        assert "state_class" not in attr
         assert attr["icon"] == "mdi:cash"
 
         sensor_15min = hass.states.get(


### PR DESCRIPTION
## Summary
- mark current electricity and gas price sensors as measurement sensors
- keep price-per-energy sensors without the monetary device class
- leave tomorrow, cheapest, most-expensive, and order sensors unchanged
- document that statistics begin after upgrade and do not backfill history

## Backward compatibility
Entity IDs, unique IDs, values, units, and existing attributes remain unchanged. The only new state attribute is state_class on current-price sensors, allowing Home Assistant to record long-term min/max/mean statistics.

## Validation
- 186 tests passed
- Ruff passed
- Pyrefly passed
- git diff --check passed

Closes #12