### PR TITLE
fix: execute FX retries and respect price block boundaries

### DIFF
--- a/custom_components/cz_energy_spot_prices/cheapest_blocks.py
+++ b/custom_components/cz_energy_spot_prices/cheapest_blocks.py
@@ -279,7 +279,9 @@ def validate_search_definition(
                 pass
             else:
                 duration = _fixed_window_duration_hours(st, et)
-                if duration < parsed_length_hours:
+                if st == et:
+                    errors["end_time"] = "start_equals_end"
+                elif duration < parsed_length_hours:
                     errors["length_hours"] = "longer_than_window"
 
     return errors
@@ -357,6 +359,7 @@ def find_price_block(
     objective: SearchObjective = SearchObjective.LOWEST,
     *,
     interval_seconds: int | None = None,
+    require_complete_window: bool = False,
 ) -> dict[str, Any] | None:
     """Find the lowest- or highest-priced consecutive block inside the window.
 
@@ -370,6 +373,24 @@ def find_price_block(
     interval_seconds = interval_seconds or _infer_interval_seconds(intervals)
     if interval_seconds is None:
         return None
+
+    interval_delta = timedelta(seconds=interval_seconds)
+    if require_complete_window:
+        covering = [
+            dt
+            for dt, _price in intervals
+            if dt < window_end and dt + interval_delta > window_start
+        ]
+        if (
+            not covering
+            or covering[0] > window_start
+            or covering[-1] + interval_delta < window_end
+            or any(
+                following - previous != interval_delta
+                for previous, following in zip(covering, covering[1:])
+            )
+        ):
+            return None
 
     try:
         required = compute_required_intervals(length_hours, interval_seconds)
@@ -396,8 +417,14 @@ def find_price_block(
     selected_end: datetime | None = None
     selected_prices: list[Decimal] | None = None
 
-    for i in range(len(filtered) - required + 1):
-        window_prices = [price for _dt, price in filtered[i : i + required]]
+    for start_index in range(len(filtered) - required + 1):
+        candidate = filtered[start_index : start_index + required]
+        if any(
+            following[0] - previous[0] != interval_delta
+            for previous, following in zip(candidate, candidate[1:])
+        ):
+            continue
+        window_prices = [price for _dt, price in candidate]
         window_sum = sum(window_prices, start=Decimal(0))
         is_better = selected_sum is None or (
             window_sum < selected_sum
@@ -406,10 +433,8 @@ def find_price_block(
         )
         if is_better:
             selected_sum = window_sum
-            selected_start = filtered[i][0]
-            selected_end = filtered[i + required - 1][0] + timedelta(
-                seconds=interval_seconds
-            )
+            selected_start = candidate[0][0]
+            selected_end = candidate[-1][0] + interval_delta
             selected_prices = window_prices
 
     if (
@@ -440,17 +465,17 @@ def _infer_interval_seconds(
 
 
 def _parse_time(value: str) -> time:
-    """Parse HH:MM string into time object."""
-    parts = value.strip().split(":")
-    hour = int(parts[0])
-    minute = int(parts[1]) if len(parts) > 1 else 0
-    return time(hour, minute)
+    """Parse a local ISO time without discarding seconds."""
+    parsed = time.fromisoformat(value.strip())
+    if parsed.tzinfo is not None:
+        raise ValueError("Search times must be local times without a UTC offset")
+    return parsed
 
 
 def _fixed_window_duration_hours(start: time, end: time) -> float:
     """Return duration in hours for a time window (handles cross-midnight)."""
-    start_min = start.hour * 60 + start.minute
-    end_min = end.hour * 60 + end.minute
-    if end_min <= start_min:
-        end_min += 24 * 60
-    return (end_min - start_min) / 60.0
+    day = datetime.min.date()
+    duration = datetime.combine(day, end) - datetime.combine(day, start)
+    if duration <= timedelta(0):
+        duration += timedelta(days=1)
+    return duration.total_seconds() / 3600

--- a/custom_components/cz_energy_spot_prices/coordinator.py
+++ b/custom_components/cz_energy_spot_prices/coordinator.py
@@ -393,6 +393,7 @@ class IntervalSpotRateData:
                 search.length_hours,
                 search.objective,
                 interval_seconds=interval_seconds,
+                require_complete_window=True,
             )
             if result is None:
                 _LOGGER.debug(
@@ -968,6 +969,7 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
 
         self._cnb = CnbRate(session=async_get_clientsession(hass))
         self._retry_attempt = 0
+        self._retry_schedule: Callable[[], None] | None = None
         self._store: Store[dict[str, str]] = Store(
             hass,
             STORAGE_VERSION,
@@ -1021,6 +1023,9 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
 
     async def async_stop(self):
         """Cancel scheduled jobs."""
+        if self._retry_schedule:
+            self._retry_schedule()
+            self._retry_schedule = None
         if self._update_schedule:
             _LOGGER.debug("Unscheduling FX coordinator")
             self._update_schedule()
@@ -1038,6 +1043,9 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
 
     async def _fetch_data_with_retry(self):
         _LOGGER.debug("FxCoordinator._fetch_data_with_retry")
+        if self._retry_schedule:
+            self._retry_schedule()
+            self._retry_schedule = None
         current_delay = min(2**self._retry_attempt, self.MAX_RETRY_DELAY)
         try:
             async with timeout(30):
@@ -1068,10 +1076,10 @@ class FxCoordinator(DataUpdateCoordinator[dict[str, Decimal] | None]):
         # ``self._update_schedule``. Otherwise the original midnight callback
         # would leak (its cancel handle would be lost) and we'd also lose the
         # daily refresh after the first failure.
-        event.async_call_later(
+        self._retry_schedule = event.async_call_later(
             self.hass,
             delay=current_delay,
-            action=lambda dt: self.async_request_refresh(),
+            action=self.on_schedule,
         )
 
         raise UpdateFailed("Failed to update CNB FX rates")

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -31,6 +31,7 @@ from custom_components.cz_energy_spot_prices.cheapest_blocks import (
     PriceBlockSearch,
     find_price_block,
     resolve_search_window,
+    validate_search_definition,
 )
 from custom_components.cz_energy_spot_prices.coordinator import (
     EntryConfig,
@@ -266,6 +267,72 @@ def test_highest_price_search_supports_tomorrow_and_fixed_windows():
     assert data.search_windows["fixed-highest"].start == fixed_start
 
 
+@pytest.mark.parametrize("interval_seconds", [900, 3600])
+@pytest.mark.parametrize("end_time", ["23:00:30", "01:00:30"])
+def test_fixed_window_preserves_seconds(interval_seconds, end_time):
+    """Whole price intervals must fit inside the exact configured times."""
+    interval = (
+        SpotRateIntervalType.QuarterHour
+        if interval_seconds == 900
+        else SpotRateIntervalType.Hour
+    )
+    search = PriceBlockSearch.from_mapping(
+        {
+            "id": "seconds",
+            "name": "Exact window",
+            "type": SearchType.FIXED,
+            "length_hours": interval_seconds / 3600,
+            "start_time": "22:00:30",
+            "end_time": end_time,
+        },
+        interval=interval,
+    )
+    assert search is not None
+    assert search.start_time == time(22, 0, 30)
+    assert search.end_time == time.fromisoformat(end_time)
+    today = datetime(2025, 10, 22, tzinfo=PRAGUE_TZ)
+    bounds = resolve_search_window(search, today + timedelta(hours=12), None)
+    assert bounds is not None
+    start, end = (bound.astimezone(UTC) for bound in bounds)
+    assert start.second == end.second == 30
+    base = start.replace(second=0)
+    step = timedelta(seconds=interval_seconds)
+    intervals = [(base + step * index, Decimal(index)) for index in range(20)]
+    result = find_price_block(
+        intervals, start, end, interval_seconds / 3600,
+        interval_seconds=interval_seconds,
+        require_complete_window=True,
+    )
+    if interval_seconds == 3600 and end_time == "23:00:30":
+        assert result is None
+    else:
+        assert result is not None
+        assert result["start"] == base + step
+        assert result["end"] <= end
+
+
+@pytest.mark.parametrize(
+    ("start_time", "end_time", "error_field", "error"),
+    [
+        ("22:00:30", "23:00:00", "length_hours", "longer_than_window"),
+        ("23:00:30", "00:00:00", "length_hours", "longer_than_window"),
+        ("22:00", "22:00:00", "end_time", "start_equals_end"),
+    ],
+)
+def test_fixed_window_validation_uses_seconds(start_time, end_time, error_field, error):
+    """Validation and persisted parsing agree on the actual window duration."""
+    search = {
+        "id": "seconds",
+        "name": "Exact window",
+        "type": SearchType.FIXED,
+        "length_hours": 1,
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+    assert validate_search_definition(search) == {error_field: error}
+    assert PriceBlockSearch.from_mapping(search, interval=SpotRateIntervalType.Hour) is None
+
+
 def test_find_price_block_requires_interval_to_end_inside_window():
     """Test partial intervals at a time window boundary are not selected."""
     base = datetime(2025, 10, 22, 20, 0, tzinfo=UTC)
@@ -282,6 +349,80 @@ def test_find_price_block_requires_interval_to_end_inside_window():
     )
 
     assert result is None
+
+
+@pytest.mark.parametrize("interval_seconds", [900, 3600])
+@pytest.mark.parametrize("objective", list(SearchObjective))
+def test_find_price_block_skips_gaps(interval_seconds, objective):
+    """Missing prices cannot stretch a block beyond its requested duration."""
+    base = datetime(2025, 10, 22, tzinfo=UTC)
+    step = timedelta(seconds=interval_seconds)
+    preferred = Decimal(-10 if objective == SearchObjective.LOWEST else 10)
+    intervals = [
+        (base, preferred),
+        (base + step * 2, preferred),
+        (base + step * 3, Decimal(0)),
+        (base + step * 4, Decimal(0)),
+    ]
+
+    result = find_price_block(
+        intervals,
+        base,
+        base + step * 5,
+        length_hours=interval_seconds * 2 / 3600,
+        objective=objective,
+        interval_seconds=interval_seconds,
+    )
+
+    assert result is not None
+    assert result["start"] == base + step * 2
+    assert result["end"] - result["start"] == step * 2
+    assert result["prices"] == [preferred, Decimal(0)]
+    assert find_price_block(
+        intervals[:2],
+        base,
+        base + step * 3,
+        length_hours=interval_seconds * 2 / 3600,
+        interval_seconds=interval_seconds,
+    ) is None
+
+
+@pytest.mark.parametrize("search_type", list(SearchType))
+def test_configured_search_requires_all_prices_in_window(search_type):
+    """Even a gap outside the winning block invalidates a configured window."""
+    today = datetime(2025, 10, 22, tzinfo=PRAGUE_TZ)
+    rates = {
+        (today + timedelta(hours=hour)).astimezone(UTC): Decimal(hour)
+        for hour in range(48)
+    }
+    config = EntryConfig(
+        commodity=Commodity.Electricity,
+        interval=SpotRateIntervalType.Hour,
+        currency=Currency.EUR,
+        currency_human="EUR",
+        unit=EnergyUnit.MWh,
+        timezone="Europe/Prague",
+        zoneinfo=PRAGUE_TZ,
+        buy_template=None,
+        sell_template=None,
+        cheapest_block_searches=[
+            PriceBlockSearch(
+                id="complete",
+                name="Complete window",
+                type=search_type,
+                length_hours=2,
+                start_time=time(18),
+                end_time=time(23),
+            )
+        ],
+    )
+    missing_hour = 45 if search_type == SearchType.TOMORROW else 21
+    with freeze_time(today + timedelta(hours=12)):
+        complete = IntervalSpotRateData(config, rates, rate_template=None)
+        assert "complete" in complete.search_windows
+        del rates[(today + timedelta(hours=missing_hour)).astimezone(UTC)]
+        incomplete = IntervalSpotRateData(config, rates, rate_template=None)
+        assert "complete" not in incomplete.search_windows
 
 
 def test_find_price_block_handles_ties_and_negative_prices():

--- a/tests/test_fx_coordinator.py
+++ b/tests/test_fx_coordinator.py
@@ -1,17 +1,79 @@
 """Tests for CNB exchange-rate coordination and persistence."""
 
+from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from freezegun import freeze_time
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from custom_components.cz_energy_spot_prices.cnb_rate import CnbRateError
 from custom_components.cz_energy_spot_prices.coordinator import FxCoordinator
 
 from . import BASE_DT, get_entry, init_integration
+
+
+async def test_retry_refreshes_rates_and_preserves_midnight_schedule(
+    hass: HomeAssistant,
+) -> None:
+    """A real timer retries a failed request without losing the daily refresh."""
+    with freeze_time(BASE_DT) as freezer:
+        await hass.config.async_set_time_zone("Europe/Prague")
+        coordinator = FxCoordinator(hass)
+        rates = {"CZK": Decimal(1), "EUR": Decimal("24.315")}
+        fetch = AsyncMock(side_effect=[CnbRateError("CNB unavailable"), rates, rates])
+        with (
+            patch.object(coordinator, "_fetch_data", fetch),
+            patch.object(coordinator._store, "async_save", AsyncMock()),
+        ):
+            await coordinator.async_refresh()
+            assert not coordinator.last_update_success
+
+            freezer.tick(timedelta(seconds=10))
+            async_fire_time_changed(hass)
+            await hass.async_block_till_done()
+            assert fetch.await_count == 2
+            assert coordinator.data == rates
+            assert coordinator.last_update_success
+
+            freezer.tick(timedelta(days=1))
+            async_fire_time_changed(hass)
+            await hass.async_block_till_done()
+            assert fetch.await_count == 3
+        await coordinator.async_stop()
+        await coordinator.async_shutdown()
+
+
+@pytest.mark.parametrize("stop", [False, True])
+async def test_pending_retry_is_cancelled(hass: HomeAssistant, stop: bool) -> None:
+    """Stopping or a successful manual refresh cancels the outstanding retry."""
+    with freeze_time(BASE_DT) as freezer:
+        coordinator = FxCoordinator(hass)
+        fetch = AsyncMock(
+            side_effect=[CnbRateError("CNB unavailable"), {"EUR": Decimal("24.315")}]
+        )
+        with (
+            patch.object(coordinator, "_fetch_data", fetch),
+            patch.object(coordinator._store, "async_save", AsyncMock()),
+        ):
+            await coordinator.async_refresh()
+            if stop:
+                await coordinator.async_stop()
+            else:
+                await coordinator.async_refresh()
+            expected_calls = fetch.await_count
+            freezer.tick(timedelta(seconds=10))
+            async_fire_time_changed(hass)
+            await hass.async_block_till_done()
+            assert fetch.await_count == expected_calls
+        await coordinator.async_stop()
+        await coordinator.async_shutdown()
 
 
 async def test_loads_persisted_rates(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

Fix three functional issues found while reviewing the recent changes:

- Run CNB retries through the existing Home Assistant callback instead of a synchronous lambda returning an unawaited coroutine. Track the retry separately from the midnight schedule and cancel it when stopping or beginning another refresh.
- Reject price-block candidates whose timestamps are not consecutive. Require continuous price coverage for configured search windows so an internal gap cannot produce a misleading lowest/highest result.
- Preserve seconds in fixed-window boundaries and duration validation, including overnight windows. Treat equivalent representations such as `22:00` and `22:00:00` as the same boundary.

## Reproduction Examples

- After a CNB request failure, the old retry lambda was classified as an executor job; the returned refresh coroutine was never awaited.
- With hourly prices at `00:00`, `02:00`, `03:00`, and `04:00`, a requested two-hour block could span `00:00-03:00` while using only two prices.
- A fixed window of `22:00:30-23:00:30` was silently truncated to `22:00-23:00`, permitting an interval before its configured start.

## Tests

Added 17 regression cases covering actual HA timer execution, daily refresh preservation, retry cancellation, hourly/quarter-hour gaps, both price objectives, complete configured windows, exact seconds, and overnight validation.

- Full suite: **205 passed** using the frozen lockfile on Home Assistant **2026.5.2**, Python **3.14.7**, Linux (WSL Ubuntu).
- `git diff --check`: passed.
- No version or dependency changes. Newer Home Assistant versions have not been tested locally.